### PR TITLE
Mirror of jenkinsci jenkins#3578

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -28,9 +28,12 @@ import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.HashMap;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Locale;
 
 public class RunParameterValue extends ParameterValue {
@@ -90,22 +93,38 @@ public class RunParameterValue extends ParameterValue {
     	return r == null ? null : r[1];
     }
 
+    public class SerializableValue implements Serializable {
+
+        @Nonnull
+        public final String jobName;
+        public final int number;
+        @Nullable
+        public final String url;
+        @Nullable
+        public final String displayName;
+        @Nullable
+        public final String buildResult;
+
+        public SerializableValue(@CheckForNull String jobName, int number, String url, String displayName, String buildResult) {
+            this.jobName = jobName;
+            this.number = number;
+            this.url = url;
+            this.displayName = displayName;
+            this.buildResult = buildResult;
+        }
+    }
+
     @Override
-    public Map<String, String> getValue() {
+    public SerializableValue getValue() {
         Run run = getRun();
 
         String url = (null == run) ? null : Jenkins.getInstance().getRootUrl() + run.getUrl();
         String displayName = (null == run) ? null : run.getDisplayName();
         String buildResult = (null == run || null == run.getResult()) ? null : run.getResult().toString();
 
-        Map<String, String> valueMap = new HashMap<>();
-        valueMap.put("url", url);
-        valueMap.put("jobName", getJobName());
-        valueMap.put("number", getNumber());
-        valueMap.put("displayName", displayName);
-        valueMap.put("buildResult", buildResult);
+        int number = Integer.parseInt(getNumber());
 
-        return valueMap;
+        return new SerializableValue(getJobName(), number, url, displayName, buildResult);
     }
 
     /**

--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import hudson.EnvVars;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.NullArgumentException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
 
@@ -105,7 +106,10 @@ public class RunParameterValue extends ParameterValue {
         @Nullable
         public final String buildResult;
 
-        public SerializableValue(@CheckForNull String jobName, int number, String url, String displayName, String buildResult) {
+        public SerializableValue(String jobName, int number, String url, String displayName, String buildResult) {
+            if (jobName == null) {
+                throw new NullArgumentException("jobName cannot be null!");
+            }
             this.jobName = jobName;
             this.number = number;
             this.url = url;

--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -28,6 +28,8 @@ import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
 
+import java.util.Map;
+import java.util.HashMap;
 import javax.annotation.CheckForNull;
 import java.util.Locale;
 
@@ -89,8 +91,21 @@ public class RunParameterValue extends ParameterValue {
     }
 
     @Override
-    public Run getValue() {
-        return getRun();
+    public Map<String, String> getValue() {
+        Run run = getRun();
+
+        String url = (null == run) ? null : Jenkins.getInstance().getRootUrl() + run.getUrl();
+        String displayName = (null == run) ? null : run.getDisplayName();
+        String buildResult = (null == run || null == run.getResult()) ? null : run.getResult().toString();
+
+        Map<String, String> valueMap = new HashMap<>();
+        valueMap.put("url", url);
+        valueMap.put("jobName", getJobName());
+        valueMap.put("number", getNumber());
+        valueMap.put("displayName", displayName);
+        valueMap.put("buildResult", buildResult);
+
+        return valueMap;
     }
 
     /**

--- a/test/src/test/java/hudson/model/RunParameterValueTest.java
+++ b/test/src/test/java/hudson/model/RunParameterValueTest.java
@@ -20,27 +20,27 @@ public class RunParameterValueTest {
         referencedBuild.setDisplayName("referenced build display name");
         int buildNumber = referencedBuild.getNumber();
 
-        RunParameterValue rbp = new RunParameterValue("run", String.format("referencedProject#%i",buildNumber));
+        RunParameterValue rbp = new RunParameterValue("run", String.format("referencedProject#%d",buildNumber));
 
-        Map<String, String> value = rbp.getValue();
+        RunParameterValue.SerializableValue value = rbp.getValue();
 
-        assertEquals(value.get("jobName"), "referencedProject");
-        assertEquals(value.get("number"), buildNumber);
-        assertEquals(value.get("url"), "http://jenkins/url");
-        assertEquals(value.get("displayName"), "referenced build display name");
-        assertEquals(value.get("buildResult"), "SUCCESS");
+        assertEquals(value.jobName, "referencedProject");
+        assertEquals(value.number, buildNumber);
+        assertEquals(value.url, j.jenkins.getRootUrl()+referencedBuild.getUrl());
+        assertEquals(value.displayName, "referenced build display name");
+        assertEquals(value.buildResult, "SUCCESS");
     }
 
     @Test public void getValueWhenJobIsNull() throws Exception {
         RunParameterValue rbp = new RunParameterValue("run", "missingProject#1");
 
-        Map<String, String> value = rbp.getValue();
+        RunParameterValue.SerializableValue value = rbp.getValue();
 
-        assertEquals(value.get("jobName"), "missingProject");
-        assertEquals(value.get("number"), 1);
-        assertEquals(value.get("url"), null);
-        assertEquals(value.get("displayName"), null);
-        assertEquals(value.get("buildResult"), null);
+        assertEquals(value.jobName, "missingProject");
+        assertEquals(value.number, 1);
+        assertEquals(value.url, null);
+        assertEquals(value.displayName, null);
+        assertEquals(value.buildResult, null);
 
     }
 }

--- a/test/src/test/java/hudson/model/RunParameterValueTest.java
+++ b/test/src/test/java/hudson/model/RunParameterValueTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.util.Map;
 import java.util.logging.Logger;
 
 public class RunParameterValueTest {
@@ -24,11 +23,11 @@ public class RunParameterValueTest {
 
         RunParameterValue.SerializableValue value = rbp.getValue();
 
-        assertEquals(value.jobName, "referencedProject");
-        assertEquals(value.number, buildNumber);
-        assertEquals(value.url, j.jenkins.getRootUrl()+referencedBuild.getUrl());
-        assertEquals(value.displayName, "referenced build display name");
-        assertEquals(value.buildResult, "SUCCESS");
+        assertEquals("referencedProject", value.jobName);
+        assertEquals(buildNumber, value.number);
+        assertEquals(j.jenkins.getRootUrl()+referencedBuild.getUrl(), value.url);
+        assertEquals("referenced build display name", value.displayName);
+        assertEquals("SUCCESS", value.buildResult);
     }
 
     @Test public void getValueWhenJobIsNull() throws Exception {
@@ -36,11 +35,10 @@ public class RunParameterValueTest {
 
         RunParameterValue.SerializableValue value = rbp.getValue();
 
-        assertEquals(value.jobName, "missingProject");
-        assertEquals(value.number, 1);
-        assertEquals(value.url, null);
-        assertEquals(value.displayName, null);
-        assertEquals(value.buildResult, null);
-
+        assertEquals("missingProject", value.jobName);
+        assertEquals(1, value.number);
+        assertEquals(null, value.url);
+        assertEquals(null, value.displayName);
+        assertEquals(null, value.buildResult);
     }
 }

--- a/test/src/test/java/hudson/model/RunParameterValueTest.java
+++ b/test/src/test/java/hudson/model/RunParameterValueTest.java
@@ -1,0 +1,46 @@
+package hudson.model;
+
+import org.junit.Rule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class RunParameterValueTest {
+    private static final Logger LOGGER = Logger.getLogger(Run.class.getName());
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test public void getValueWhenJobExists() throws Exception {
+        FreeStyleProject referencedProject = j.createFreeStyleProject("referencedProject");
+        FreeStyleBuild referencedBuild = referencedProject.scheduleBuild2(0).get();
+        referencedBuild.setDisplayName("referenced build display name");
+        int buildNumber = referencedBuild.getNumber();
+
+        RunParameterValue rbp = new RunParameterValue("run", String.format("referencedProject#%i",buildNumber));
+
+        Map<String, String> value = rbp.getValue();
+
+        assertEquals(value.get("jobName"), "referencedProject");
+        assertEquals(value.get("number"), buildNumber);
+        assertEquals(value.get("url"), "http://jenkins/url");
+        assertEquals(value.get("displayName"), "referenced build display name");
+        assertEquals(value.get("buildResult"), "SUCCESS");
+    }
+
+    @Test public void getValueWhenJobIsNull() throws Exception {
+        RunParameterValue rbp = new RunParameterValue("run", "missingProject#1");
+
+        Map<String, String> value = rbp.getValue();
+
+        assertEquals(value.get("jobName"), "missingProject");
+        assertEquals(value.get("number"), 1);
+        assertEquals(value.get("url"), null);
+        assertEquals(value.get("displayName"), null);
+        assertEquals(value.get("buildResult"), null);
+
+    }
+}


### PR DESCRIPTION
Mirror of jenkinsci jenkins#3578
See [JENKINS-52174](https://issues.jenkins-ci.org/browse/JENKINS-52174).

RunParameterValue.getValue currently returns a Run, as a result it can't be used in a pipeline script.
Changing it to return something serializable should allow it to be used there.
`getRun` is already available and public if a Run is ever required. (using github search on the `jenkinsci/*` organization yields no usages of getValue on a RunParameterValue)

### Proposed changelog entries

* RunParameterValue.getValue() now returns a serializable record. The Run it used tor refer to is still available by .getRun().

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests


### Desired reviewers
<at>abayer 

Not yet ready for merge, haven't checked that it's available in `params` in a pipeline after this change.

