### PR TITLE
Mirror of jenkinsci jenkins#3577

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -25,7 +25,9 @@ package hudson;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Proc.LocalProc;
+import hudson.model.BuildListener;
 import hudson.model.Computer;
+import hudson.model.Run;
 import hudson.util.QuotedStringTokenizer;
 import jenkins.model.Jenkins;
 import hudson.model.TaskListener;
@@ -804,6 +806,22 @@ public abstract class Launcher {
         Launcher l = this;
         for (LauncherDecorator d : LauncherDecorator.all())
             l = d.decorate(l,node);
+        return l;
+    }
+
+    /**
+     * Returns a decorated {@link Launcher} for the given {@link hudson.model.Run}.
+     *
+     * @param run Run for which this launcher is created.
+     * @param listener Task listener
+     * @return Decorated instance of the Launcher.
+     * @since TODO
+     */
+    @Nonnull
+    public final Launcher decorateFor(@Nonnull Run run, @Nonnull BuildListener listener) {
+        Launcher l = this;
+        for (LauncherDecorator d : LauncherDecorator.all())
+            l = d.decorate(l, run, listener);
         return l;
     }
 

--- a/core/src/main/java/hudson/LauncherDecorator.java
+++ b/core/src/main/java/hudson/LauncherDecorator.java
@@ -1,7 +1,10 @@
 package hudson;
 
+import hudson.model.BuildListener;
 import hudson.model.Node;
 import hudson.model.Executor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapper;
 import javax.annotation.Nonnull;
 
@@ -40,7 +43,22 @@ public abstract class LauncherDecorator implements ExtensionPoint {
      * @see Launcher#decorateByPrefix(String[])
      */
     @Nonnull
-    public abstract Launcher decorate(@Nonnull Launcher launcher, @Nonnull Node node);
+    public Launcher decorate(@Nonnull Launcher launcher, @Nonnull Node node) {
+        return launcher;
+    }
+
+    /**
+     * Decorates Launcher by Run
+     * @param launcher Launcher to be decorated
+     * @param run Run
+     * @param listener Event Listener
+     * @return Decorated launcher or the passed launcher if not documented
+     * @since TODO
+     */
+    @Nonnull
+    public Launcher decorate(@Nonnull Launcher launcher, @Nonnull Run run, BuildListener listener) {
+        return launcher;
+    }
 
     /**
      * Returns all the registered {@link LauncherDecorator}s.

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -36,6 +36,8 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.FeedAdapter;
 import hudson.Functions;
+import hudson.Launcher;
+import hudson.LauncherDecorator;
 import hudson.console.AnnotatedLargeText;
 import hudson.console.ConsoleLogFilter;
 import hudson.console.ConsoleNote;
@@ -44,6 +46,8 @@ import hudson.console.PlainTextConsoleOutputStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
+
+import hudson.slaves.NodeProperty;
 import jenkins.util.SystemProperties;
 import hudson.Util;
 import hudson.XmlFile;
@@ -2577,6 +2581,24 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             returnedResult = new RedirectUp();
         }
         return returnedResult;
+    }
+
+    /**
+     * Creates a {@link Launcher} that this build will use. This can be overridden by derived types
+     * to decorate the resulting {@link Launcher}.
+     *
+     * @param listener
+     *      Always non-null. Connected to the main build output.
+     * @param node
+     *      Node for which the launcher is created.
+     * @since TODO
+     */
+    @Nonnull
+    protected Launcher createLauncher(@Nonnull Node node, @Nonnull BuildListener listener)
+            throws IOException, InterruptedException {
+        Launcher l = node.createLauncher(listener);
+        l.decorateFor(this, listener);
+        return l;
     }
 
     public static class RedirectUp {


### PR DESCRIPTION
Mirror of jenkinsci jenkins#3577
Just detaching some code from #3575 which we will unlikely need in the current implementation. It may be still useful as overall generalization, please let me know if somebody finds it useful.

See [JENKINS-52914](https://issues.jenkins-ci.org/browse/JENKINS-52914).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Developer: Introduce `Run#createLauncher()` and `LauncherDecorator#decorateFor(Run)` API
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<at>mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

