### PR TITLE
Mirror of jenkinsci jenkins#3445

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2462,7 +2462,7 @@ public class Queue extends ResourceController implements Saveable {
 
         public CauseOfBlockage getCauseOfBlockage() {
             long diff = System.currentTimeMillis() - timestamp.getTimeInMillis();
-            if (diff <= 0)
+            if (diff <= 10000)
                 return CauseOfBlockage.fromMessage(Messages._Queue_InQuietPeriod(Util.getTimeSpanString(diff)));
             else
                 return CauseOfBlockage.fromMessage(Messages._Queue_Unknown());

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2461,8 +2461,8 @@ public class Queue extends ResourceController implements Saveable {
         }
 
         public CauseOfBlockage getCauseOfBlockage() {
-            long diff = timestamp.getTimeInMillis() - System.currentTimeMillis();
-            if (diff > 0)
+            long diff = System.currentTimeMillis() - timestamp.getTimeInMillis();
+            if (diff <= 0)
                 return CauseOfBlockage.fromMessage(Messages._Queue_InQuietPeriod(Util.getTimeSpanString(diff)));
             else
                 return CauseOfBlockage.fromMessage(Messages._Queue_Unknown());


### PR DESCRIPTION
Mirror of jenkinsci jenkins#3445
In #3436, I started gathering queue API statistics.

Currently:
```
1122 / 7087 jenkins.queue.log
      3 ???
     68 All nodes of label ‘LABEL’ are offline
    765 Build # is already in progress (...)
     31 Executor slot already in use
     11 In the quiet period. Expires in # sec
   1203 NODE doesn’t have label LABEL
   2848 NODE is offline
     22 NODE is reserved for jobs with matching label expression
    554 Upstream project PROJECT is already building.
    560 Waiting for next available executor on LABEL
   4575 Waiting for next available executor on NODE
```

For each of the three times that I hit this edge `public CauseOfBlockage getCauseOfBlockage() -> CauseOfBlockage.fromMessage(Messages._Queue_Unknown())`, the difference between `inQueueSince` and `timestamp` was "-5000". Here's an example:
```js
{ _class: 'hudson.model.Queue',
  discoverableItems: [],
  items:
   [ { _class: 'hudson.model.Queue$WaitingItem',
       actions: [Array],
       blocked: false,
       buildable: false,
       id: 30826,
       inQueueSince: 1525984983231,
       params: '',
       stuck: false,
       task: [Object],
       url: 'queue/item/30826/',
       why: '???',
       timestamp: 1525984988231 } ] }
```

I'm making two changes:
1. Getting the time first instead of second because time ticks forward which means that the later we get it, the more likely it is to be negative and thus "confusing".
2. Including 10,000 milliseconds (10 seconds) of tolerance.

For my system, 5,000 milliseconds (5 seconds) would be enough for each of the three times I've hit this edge, but picking the exact count that makes my edge pass makes me queasy.
