### PR TITLE
Mirror of jenkinsci jenkins#4037

### DIFF
--- a/core/src/main/java/hudson/DNSMultiCast.java
+++ b/core/src/main/java/hudson/DNSMultiCast.java
@@ -97,6 +97,21 @@ public class DNSMultiCast implements Closeable {
 
     public static boolean disabled = SystemProperties.getBoolean(DNSMultiCast.class.getName()+".disabled");
 
+    /**
+     * Class that extends {@link JmDNSImpl} to add an abort method. Since {@link javax.jmdns.JmDNS#close()} might
+     * make the instance hang during the shutdown, the abort method terminate uncleanly, but rapidly and
+     * without blocking.
+     *
+     * Initially it was part of the jenkinsci/jmdns forked library, but now this class is responsible for aborting,
+     * allowing to have a direct and clean dependency to the original library.
+     *
+     * The abort() method is pretty similar to close() method. To access private methods and fields uses
+     * reflection.
+     *
+     * @since 2.178
+     *
+     * See JENKINS-25369 for further details
+     */
     private static class JenkinsJmDNS extends JmDNSImpl {
         private static Logger logger = Logger.getLogger(JmDNSImpl.class.getName());
         private final Class parent;


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4037
See [JENKINS-25369](https://issues.jenkins-ci.org/browse/JENKINS-25369).

This PR is a follow up of #4021. It adds the javadoc for the new class `JenkinsJmDNS`

### Proposed changelog entries

* Internal: Add the javadoc for the new class `JenkinsJmDNS`

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

<at>oleg-nenashev <at>batmat 

