### PR TITLE
Mirror of jenkinsci jenkins#4040

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -284,24 +284,6 @@ THE SOFTWARE.
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>ssh-slaves</artifactId>
-                  <version>1.15</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>credentials</artifactId>
-                  <version>2.1.2</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>ssh-credentials</artifactId>
-                  <version>1.10</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>subversion</artifactId>
                   <version>1.54</version>
                   <type>hpi</type>
@@ -322,12 +304,6 @@ THE SOFTWARE.
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>javadoc</artifactId>
                   <version>1.1</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>translation</artifactId>
-                  <version>1.10</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -362,12 +362,6 @@ THE SOFTWARE.
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>script-security</artifactId>
-                  <version>1.56</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>junit</artifactId>
                   <version>1.6</version>
                   <type>hpi</type>


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4040
Remove plugins bundled for promotional purposes only, and their dependencies.

References:

* https://github.com/jenkinsci/jenkins/commit/85e7c6b984cfac1ddb190d33c71610df943edba5 ssh-slaves added without detachment
* https://github.com/jenkinsci/jenkins/commit/8a3e909d266ea59d7179fef21350e9aec1f4b245 added credentials plugins as new dependency
* https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/split-plugins.txt lack of entries for these plugins

**!!! Very untested !!!**

### Proposed changelog entries

* Remove plugins bundled to promote their use before Jenkins 2.0 replaced the concept of plugins installed by default with the setup wizard.

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

<at>jenkinsci/code-reviewers
