### PR TITLE
Mirror of jenkinsci jenkins#4042

### DIFF
--- a/core/src/main/java/hudson/DependencyRunner.java
+++ b/core/src/main/java/hudson/DependencyRunner.java
@@ -59,7 +59,7 @@ public class DependencyRunner implements Runnable {
             Set<AbstractProject> topLevelProjects = new HashSet<AbstractProject>();
             // Get all top-level projects
             LOGGER.fine("assembling top level projects");
-            for (AbstractProject p : Jenkins.getInstance().allItems(AbstractProject.class))
+            for (AbstractProject p : Jenkins.get().allItems(AbstractProject.class))
                 if (p.getUpstreamProjects().size() == 0) {
                     LOGGER.fine("adding top level project " + p.getName());
                     topLevelProjects.add(p);

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -263,13 +263,13 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         public GuiceFinder() {
             refreshExtensionAnnotations();
 
-            SezpozModule extensions = new SezpozModule(loadSezpozIndices(Jenkins.getInstance().getPluginManager().uberClassLoader));
+            SezpozModule extensions = new SezpozModule(loadSezpozIndices(Jenkins.get().getPluginManager().uberClassLoader));
 
             List<Module> modules = new ArrayList<>();
             modules.add(new AbstractModule() {
                 @Override
                 protected void configure() {
-                    Jenkins j = Jenkins.getInstance();
+                    Jenkins j = Jenkins.get();
                     bind(Jenkins.class).toInstance(j);
                     bind(PluginManager.class).toInstance(j.getPluginManager());
                 }
@@ -291,7 +291,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             }
 
             // expose Injector via lookup mechanism for interop with non-Guice clients
-            Jenkins.getInstance().lookup.set(Injector.class,new ProxyInjector() {
+            Jenkins.get().lookup.set(Injector.class,new ProxyInjector() {
                 protected Injector resolve() {
                     return getContainer();
                 }
@@ -642,7 +642,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             // 4. thread Y decides to load extensions, now blocked on SZ.
             // 5. dead lock
             if (indices==null) {
-                ClassLoader cl = Jenkins.getInstance().getPluginManager().uberClassLoader;
+                ClassLoader cl = Jenkins.get().getPluginManager().uberClassLoader;
                 indices = ImmutableList.copyOf(Index.load(Extension.class, Object.class, cl));
             }
             return indices;
@@ -676,7 +676,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         static <T extends Annotation> List<IndexItem<T,Object>> listDelta(Class<T> annotationType, List<? extends IndexItem<?,Object>> old) {
             // list up newly discovered components
             final List<IndexItem<T,Object>> delta = Lists.newArrayList();
-            ClassLoader cl = Jenkins.getInstance().getPluginManager().uberClassLoader;
+            ClassLoader cl = Jenkins.get().getPluginManager().uberClassLoader;
             for (IndexItem<T,Object> ii : Index.load(annotationType, Object.class, cl)) {
                 if (!old.contains(ii)) {
                     delta.add(ii);

--- a/core/src/main/java/hudson/ExtensionListView.java
+++ b/core/src/main/java/hudson/ExtensionListView.java
@@ -58,7 +58,7 @@ public class ExtensionListView {
     public static <T> List<T> createList(final Class<T> type) {
         return new AbstractList<T>() {
             private ExtensionList<T> storage() {
-                return Jenkins.getInstance().getExtensionList(type);
+                return Jenkins.get().getExtensionList(type);
             }
 
             @Override
@@ -103,7 +103,7 @@ public class ExtensionListView {
     public static <T> CopyOnWriteList<T> createCopyOnWriteList(final Class<T> type) {
         return new CopyOnWriteList<T>() {
             private ExtensionList<T> storage() {
-                return Jenkins.getInstance().getExtensionList(type);
+                return Jenkins.get().getExtensionList(type);
             }
 
             @Override

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2954,7 +2954,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     private static void checkPermissionForValidate() {
         AccessControlled subject = Stapler.getCurrentRequest().findAncestorObject(AbstractProject.class);
         if (subject == null)
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         else
             subject.checkPermission(Item.CONFIGURE);
     }

--- a/core/src/main/java/hudson/FileSystemProvisioner.java
+++ b/core/src/main/java/hudson/FileSystemProvisioner.java
@@ -177,7 +177,7 @@ public abstract class FileSystemProvisioner implements ExtensionPoint, Describab
     public abstract WorkspaceSnapshot snapshot(AbstractBuild<?,?> build, FilePath ws, String glob, TaskListener listener) throws IOException, InterruptedException;
 
     public FileSystemProvisionerDescriptor getDescriptor() {
-        return (FileSystemProvisionerDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (FileSystemProvisionerDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -189,7 +189,7 @@ public abstract class FileSystemProvisioner implements ExtensionPoint, Describab
      * Returns all the registered {@link FileSystemProvisioner} descriptors.
      */
     public static DescriptorExtensionList<FileSystemProvisioner,FileSystemProvisionerDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(FileSystemProvisioner.class);
+        return Jenkins.get().getDescriptorList(FileSystemProvisioner.class);
     }
 
     /**

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -287,7 +287,7 @@ public class Functions {
     }
 
     public JDK.DescriptorImpl getJDKDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(JDK.DescriptorImpl.class);
+        return Jenkins.get().getDescriptorByType(JDK.DescriptorImpl.class);
     }
 
     /**
@@ -762,7 +762,7 @@ public class Functions {
     }
 
     public static void checkPermission(Permission permission) throws IOException, ServletException {
-        checkPermission(Jenkins.getInstance(),permission);
+        checkPermission(Jenkins.get(),permission);
     }
 
     public static void checkPermission(AccessControlled object, Permission permission) throws IOException, ServletException {
@@ -791,7 +791,7 @@ public class Functions {
                     return;
                 }
             }
-            checkPermission(Jenkins.getInstance(),permission);
+            checkPermission(Jenkins.get(),permission);
         }
     }
 
@@ -802,7 +802,7 @@ public class Functions {
      *      If null, returns true. This defaulting is convenient in making the use of this method terse.
      */
     public static boolean hasPermission(Permission permission) throws IOException, ServletException {
-        return hasPermission(Jenkins.getInstance(),permission);
+        return hasPermission(Jenkins.get(),permission);
     }
 
     /**
@@ -822,7 +822,7 @@ public class Functions {
                     return ((AccessControlled)o).hasPermission(permission);
                 }
             }
-            return Jenkins.getInstance().hasPermission(permission);
+            return Jenkins.get().hasPermission(permission);
         }
     }
 
@@ -845,7 +845,7 @@ public class Functions {
      * Infers the hudson installation URL from the given request.
      */
     public static String inferHudsonURL(StaplerRequest req) {
-        String rootUrl = Jenkins.getInstance().getRootUrl();
+        String rootUrl = Jenkins.get().getRootUrl();
         if(rootUrl !=null)
             // prefer the one explicitly configured, to work with load-balancer, frontend, etc.
             return rootUrl;
@@ -912,7 +912,7 @@ public class Functions {
     @Restricted(DoNotUse.class)
     @RestrictedSince("2.12")
     public static List<Descriptor<ComputerLauncher>> getComputerLauncherDescriptors() {
-        return Jenkins.getInstance().<ComputerLauncher,Descriptor<ComputerLauncher>>getDescriptorList(ComputerLauncher.class);
+        return Jenkins.get().<ComputerLauncher,Descriptor<ComputerLauncher>>getDescriptorList(ComputerLauncher.class);
     }
 
     /**
@@ -951,7 +951,7 @@ public class Functions {
     @RestrictedSince("2.12")
     public static List<NodePropertyDescriptor> getNodePropertyDescriptors(Class<? extends Node> clazz) {
         List<NodePropertyDescriptor> result = new ArrayList<NodePropertyDescriptor>();
-        Collection<NodePropertyDescriptor> list = (Collection) Jenkins.getInstance().getDescriptorList(NodeProperty.class);
+        Collection<NodePropertyDescriptor> list = (Collection) Jenkins.get().getDescriptorList(NodeProperty.class);
         for (NodePropertyDescriptor npd : list) {
             if (npd.isApplicable(clazz)) {
                 result.add(npd);
@@ -967,7 +967,7 @@ public class Functions {
      */
     public static List<NodePropertyDescriptor> getGlobalNodePropertyDescriptors() {
         List<NodePropertyDescriptor> result = new ArrayList<NodePropertyDescriptor>();
-        Collection<NodePropertyDescriptor> list = (Collection) Jenkins.getInstance().getDescriptorList(NodeProperty.class);
+        Collection<NodePropertyDescriptor> list = (Collection) Jenkins.get().getDescriptorList(NodeProperty.class);
         for (NodePropertyDescriptor npd : list) {
             if (npd.isApplicableAsGlobal()) {
                 result.add(npd);
@@ -1010,7 +1010,7 @@ public class Functions {
         List<Descriptor> answer = new ArrayList<Descriptor>(r.size());
         for (Tag d : r) answer.add(d.d);
 
-        return DescriptorVisibilityFilter.apply(Jenkins.getInstance(),answer);
+        return DescriptorVisibilityFilter.apply(Jenkins.get(),answer);
     }
 
     /**
@@ -1110,7 +1110,7 @@ public class Functions {
             ItemGroup ig = i.getParent();
             url = i.getShortUrl()+url;
 
-            if(ig== Jenkins.getInstance() || (view != null && ig == view.getOwner().getItemGroup())) {
+            if(ig== Jenkins.get() || (view != null && ig == view.getOwner().getItemGroup())) {
                 assert i instanceof TopLevelItem;
                 if (view != null) {
                     // assume p and the current page belong to the same view, so return a relative path
@@ -1682,7 +1682,7 @@ public class Functions {
     public String getServerName() {
         // Try to infer this from the configured root URL.
         // This makes it work correctly when Hudson runs behind a reverse proxy.
-        String url = Jenkins.getInstance().getRootUrl();
+        String url = Jenkins.get().getRootUrl();
         try {
             if(url!=null) {
                 String host = new URL(url).getHost();

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -147,7 +147,7 @@ public abstract class Launcher {
     @Deprecated
     @CheckForNull
     public Computer getComputer() {
-        for( Computer c : Jenkins.getInstance().getComputers() )
+        for( Computer c : Jenkins.get().getComputers() )
             if(c.getChannel()==channel)
                 return c;
         return null;

--- a/core/src/main/java/hudson/LocalPluginManager.java
+++ b/core/src/main/java/hudson/LocalPluginManager.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 public class LocalPluginManager extends PluginManager {
     /**
      * Creates a new LocalPluginManager
-     * @param context Servlet context. Provided for compatibility as {@code Jenkins.getInstance().servletContext} should be used.
+     * @param context Servlet context. Provided for compatibility as {@code Jenkins.get().servletContext} should be used.
      * @param rootDir Jenkins home directory.
      */
     public LocalPluginManager(@CheckForNull ServletContext context, @NonNull File rootDir) {

--- a/core/src/main/java/hudson/Plugin.java
+++ b/core/src/main/java/hudson/Plugin.java
@@ -290,7 +290,7 @@ public abstract class Plugin implements Saveable {
      */
     protected XmlFile getConfigXml() {
         return new XmlFile(Jenkins.XSTREAM,
-                new File(Jenkins.getInstance().getRootDir(),wrapper.getShortName()+".xml"));
+                new File(Jenkins.get().getRootDir(),wrapper.getShortName()+".xml"));
     }
 
 

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1525,7 +1525,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         final UpdateCenter updateCenter = jenkins.getUpdateCenter();
         final Authentication currentAuth = Jenkins.getAuthentication();
 
-        if (!Jenkins.get().getInstallState().isSetupComplete()) {
+        if (!Jenkins.getInstanceOrNull().getInstallState().isSetupComplete()) {
             jenkins.setInstallState(InstallState.INITIAL_PLUGINS_INSTALLING);
             updateCenter.persistInstallStatus();
             new Thread() {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1525,7 +1525,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         final UpdateCenter updateCenter = jenkins.getUpdateCenter();
         final Authentication currentAuth = Jenkins.getAuthentication();
 
-        if (!Jenkins.getInstanceOrNull().getInstallState().isSetupComplete()) {
+        if (!jenkins.getInstallState().isSetupComplete()) {
             jenkins.setInstallState(InstallState.INITIAL_PLUGINS_INSTALLING);
             updateCenter.persistInstallStatus();
             new Thread() {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -369,7 +369,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     public Api getApi() {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         return new Api(this);
     }
 
@@ -533,7 +533,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                  * Once the plugins are listed, schedule their initialization.
                  */
                 public void run(Reactor session) throws Exception {
-                    Jenkins.getInstance().lookup.set(PluginInstanceStore.class, new PluginInstanceStore());
+                    Jenkins.get().lookup.set(PluginInstanceStore.class, new PluginInstanceStore());
                     TaskGraphBuilder g = new TaskGraphBuilder();
 
                     // schedule execution of loading plugins
@@ -924,7 +924,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 p.resolvePluginDependencies();
                 strategy.load(p);
 
-                Jenkins.getInstance().refreshExtensions();
+                Jenkins.get().refreshExtensions();
 
                 p.getPlugin().postInitialize();
             } catch (Exception e) {
@@ -1328,7 +1328,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      */
     @Restricted(DoNotUse.class) // WebOnly
     public HttpResponse doPlugins() {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         JSONArray response = new JSONArray();
         Map<String,JSONObject> allPlugins = new HashMap<>();
         for (PluginWrapper plugin : plugins) {
@@ -1375,10 +1375,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @RequirePOST
     public HttpResponse doUpdateSources(StaplerRequest req) throws IOException {
-        Jenkins.getInstance().checkPermission(CONFIGURE_UPDATECENTER);
+        Jenkins.get().checkPermission(CONFIGURE_UPDATECENTER);
 
         if (req.hasParameter("remove")) {
-            UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
+            UpdateCenter uc = Jenkins.get().getUpdateCenter();
             BulkChange bc = new BulkChange(uc);
             try {
                 for (String id : req.getParameterValues("sources"))
@@ -1400,7 +1400,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @RequirePOST
     @Restricted(DoNotUse.class) // WebOnly
     public void doInstallPluginsDone() {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         j.checkPermission(Jenkins.ADMINISTER);
         InstallUtil.proceedToNextStateFrom(InstallState.INITIAL_PLUGINS_INSTALLING);
     }
@@ -1410,7 +1410,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      */
     @RequirePOST
     public void doInstall(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         Set<String> plugins = new LinkedHashSet<>();
 
         Enumeration<String> en = req.getParameterNames();
@@ -1439,7 +1439,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @RequirePOST
     @Restricted(DoNotUse.class) // WebOnly
     public HttpResponse doInstallPlugins(StaplerRequest req) throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         String payload = IOUtils.toString(req.getInputStream(), req.getCharacterEncoding());
         JSONObject request = JSONObject.fromObject(payload);
         JSONArray pluginListJSON = request.getJSONArray("plugins");
@@ -1521,11 +1521,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     private void trackInitialPluginInstall(@Nonnull final List<Future<UpdateCenter.UpdateCenterJob>> installJobs) {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         final UpdateCenter updateCenter = jenkins.getUpdateCenter();
         final Authentication currentAuth = Jenkins.getAuthentication();
 
-        if (!Jenkins.getInstance().getInstallState().isSetupComplete()) {
+        if (!Jenkins.get().getInstallState().isSetupComplete()) {
             jenkins.setInstallState(InstallState.INITIAL_PLUGINS_INSTALLING);
             updateCenter.persistInstallStatus();
             new Thread() {
@@ -1589,7 +1589,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     private UpdateSite.Plugin getPlugin(String pluginName, String siteName) {
-        UpdateSite updateSite = Jenkins.getInstance().getUpdateCenter().getById(siteName);
+        UpdateSite updateSite = Jenkins.get().getUpdateCenter().getById(siteName);
         if (updateSite == null) {
             throw new Failure("No such update center: " + siteName);
         }
@@ -1601,7 +1601,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      */
     @RequirePOST
     public HttpResponse doSiteConfigure(@QueryParameter String site) throws IOException {
-        Jenkins hudson = Jenkins.getInstance();
+        Jenkins hudson = Jenkins.get();
         hudson.checkPermission(CONFIGURE_UPDATECENTER);
         UpdateCenter uc = hudson.getUpdateCenter();
         PersistedList<UpdateSite> sites = uc.getSites();
@@ -1616,7 +1616,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @RequirePOST
     public HttpResponse doProxyConfigure(StaplerRequest req) throws IOException, ServletException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(CONFIGURE_UPDATECENTER);
 
         ProxyConfiguration pc = req.bindJSON(ProxyConfiguration.class, req.getSubmittedForm());
@@ -1636,7 +1636,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @RequirePOST
     public HttpResponse doUploadPlugin(StaplerRequest req) throws IOException, ServletException {
         try {
-            Jenkins.getInstance().checkPermission(UPLOAD_PLUGINS);
+            Jenkins.get().checkPermission(UPLOAD_PLUGINS);
 
             ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory());
 
@@ -1702,7 +1702,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @Restricted(NoExternalUse.class)
     @RequirePOST public HttpResponse doCheckUpdatesServer() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         // We'll check the update servers with a try-retry mechanism. The retrier is built with a builder
         Retrier<FormValidation> updateServerRetrier = new Retrier.Builder<>(
@@ -1798,7 +1798,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     public Descriptor<ProxyConfiguration> getProxyDescriptor() {
-        return Jenkins.getInstance().getDescriptor(ProxyConfiguration.class);
+        return Jenkins.get().getDescriptor(ProxyConfiguration.class);
     }
 
     /**
@@ -1820,9 +1820,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * @since 1.483
      */
     public List<Future<UpdateCenter.UpdateCenterJob>> prevalidateConfig(InputStream configXml) throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         List<Future<UpdateCenter.UpdateCenterJob>> jobs = new ArrayList<>();
-        UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
+        UpdateCenter uc = Jenkins.get().getUpdateCenter();
         // TODO call uc.updateAllSites() when available? perhaps not, since we should not block on network here
         for (Map.Entry<String,VersionNumber> requestedPlugin : parseRequestedPlugins(configXml).entrySet()) {
             PluginWrapper pw = getPlugin(requestedPlugin.getKey());
@@ -1882,7 +1882,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      */
     @RequirePOST
     public JSONArray doPrevalidateConfig(StaplerRequest req) throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         JSONArray response = new JSONArray();
 
@@ -2151,7 +2151,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         public boolean isActivated() {
             if(pluginsWithCycle == null){
                 pluginsWithCycle = new ArrayList<>();
-                for (PluginWrapper p : Jenkins.getInstance().getPluginManager().getPlugins()) {
+                for (PluginWrapper p : Jenkins.get().getPluginManager().getPlugins()) {
                     if(p.hasCycleDependency()){
                         pluginsWithCycle.add(p);
                         isActive = true;
@@ -2191,7 +2191,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
          * @param message the message to show (plain text)
          */
         public void ifPluginOlderThenReport(String pluginName, String requiredVersion, String message){
-            Plugin plugin = Jenkins.getInstance().getPlugin(pluginName);
+            Plugin plugin = Jenkins.get().getPlugin(pluginName);
             if(plugin != null){
                 if(plugin.getWrapper().getVersionNumber().isOlderThan(new VersionNumber(requiredVersion))) {
                     pluginsToBeUpdated.put(pluginName, new PluginUpdateInfo(pluginName, message));
@@ -2236,7 +2236,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         }
         return this;
     }

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -402,7 +402,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     }
 
     public Api getApi() {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         return new Api(this);
     }
 
@@ -902,7 +902,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      *      the user may have installed a plugin locally developed.
      */
     public UpdateSite.Plugin getUpdateInfo() {
-        UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
+        UpdateCenter uc = Jenkins.get().getUpdateCenter();
         UpdateSite.Plugin p = uc.getPlugin(getShortName(), getVersionNumber());
         if(p!=null && p.isNewerThan(getVersion())) return p;
         return null;
@@ -912,7 +912,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * returns the {@link hudson.model.UpdateSite.Plugin} object, or null.
      */
     public UpdateSite.Plugin getInfo() {
-        UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
+        UpdateCenter uc = Jenkins.get().getUpdateCenter();
         UpdateSite.Plugin p = uc.getPlugin(getShortName(), getVersionNumber());
         if (p != null) return p;
         return uc.getPlugin(getShortName());
@@ -965,7 +965,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * Where is the backup file?
      */
     public File getBackupFile() {
-        return new File(Jenkins.getInstance().getRootDir(),"plugins/"+getShortName() + ".bak");
+        return new File(Jenkins.get().getRootDir(),"plugins/"+getShortName() + ".bak");
     }
 
     /**
@@ -1141,14 +1141,14 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 //
     @RequirePOST
     public HttpResponse doMakeEnabled() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         enable();
         return HttpResponses.ok();
     }
 
     @RequirePOST
     public HttpResponse doMakeDisabled() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         disable();
         return HttpResponses.ok();
     }
@@ -1156,7 +1156,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     @RequirePOST
     @Deprecated
     public HttpResponse doPin() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         // See https://groups.google.com/d/msg/jenkinsci-dev/kRobm-cxFw8/6V66uhibAwAJ
         LOGGER.log(WARNING, "Call to pin plugin has been ignored. Plugin name: " + shortName);
         return HttpResponses.ok();
@@ -1165,7 +1165,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     @RequirePOST
     @Deprecated
     public HttpResponse doUnpin() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         // See https://groups.google.com/d/msg/jenkinsci-dev/kRobm-cxFw8/6V66uhibAwAJ
         LOGGER.log(WARNING, "Call to unpin plugin has been ignored. Plugin name: " + shortName);
         return HttpResponses.ok();

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -235,7 +235,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
     }
 
     public static XmlFile getXmlFile() {
-        return new XmlFile(XSTREAM, new File(Jenkins.getInstance().getRootDir(), "proxy.xml"));
+        return new XmlFile(XSTREAM, new File(Jenkins.get().getRootDir(), "proxy.xml"));
     }
 
     public static ProxyConfiguration load() throws IOException {
@@ -332,7 +332,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
     private static ProxyConfiguration _get() {
         JenkinsJVM.checkJenkinsJVM();
         // this code could be called between the JVM flag being set and theInstance initialized
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         return jenkins == null ? null : jenkins.proxy;
     }
 
@@ -379,7 +379,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
                 @QueryParameter("userName") String userName, @QueryParameter("password") String password,
                 @QueryParameter("noProxyHost") String noProxyHost) {
 
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
             if (Util.fixEmptyAndTrim(testUrl) == null) {
                 return FormValidation.error(Messages.ProxyConfiguration_TestUrlRequired());

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -151,7 +151,7 @@ public final class TcpSlaveAgentListener extends Thread {
      * @since 2.16
      */
     public String getAgentProtocolNames() {
-        return StringUtils.join(Jenkins.getInstance().getAgentProtocols(), ", ");
+        return StringUtils.join(Jenkins.get().getAgentProtocols(), ", ");
     }
 
     /**
@@ -267,7 +267,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     String protocol = s.substring(9);
                     AgentProtocol p = AgentProtocol.of(protocol);
                     if (p!=null) {
-                        if (Jenkins.getInstance().getAgentProtocols().contains(protocol)) {
+                        if (Jenkins.get().getAgentProtocols().contains(protocol)) {
                             LOGGER.log(p instanceof PingAgentProtocol ? Level.FINE : Level.INFO, "Accepted {0} connection #{1} from {2}", new Object[] {protocol, id, this.s.getRemoteSocketAddress()});
                             p.handle(this.s);
                         } else {
@@ -484,7 +484,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     if (originThread.isAlive()) {
                         originThread.interrupt();
                     }
-                    int port = Jenkins.getInstance().getSlaveAgentPort();
+                    int port = Jenkins.get().getSlaveAgentPort();
                     if (port != -1) {
                         new TcpSlaveAgentListener(port).start();
                         LOGGER.log(Level.INFO, "Restarted TcpSlaveAgentListener");

--- a/core/src/main/java/hudson/cli/ListPluginsCommand.java
+++ b/core/src/main/java/hudson/cli/ListPluginsCommand.java
@@ -47,7 +47,7 @@ public class ListPluginsCommand extends CLICommand {
     public String name;
 
     protected int run() {
-        Jenkins h = Jenkins.getInstance();
+        Jenkins h = Jenkins.get();
         h.checkPermission(Jenkins.ADMINISTER);
         
         PluginManager pluginManager = h.getPluginManager();

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -124,7 +124,7 @@ public class AnnotatedLargeText<T> extends LargeText {
 
                 try (ObjectInputStream ois = new ObjectInputStreamEx(new GZIPInputStream(
                         new CipherInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(base64.getBytes(StandardCharsets.UTF_8))), sym)),
-                        Jenkins.getInstance().pluginManager.uberClassLoader)) {
+                        Jenkins.get().pluginManager.uberClassLoader)) {
                     long timestamp = ois.readLong();
                     if (TimeUnit.HOURS.toMillis(1) > abs(System.currentTimeMillis()-timestamp))
                         // don't deserialize something too old to prevent a replay attack

--- a/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
@@ -92,6 +92,6 @@ public abstract class ConsoleAnnotationDescriptor extends Descriptor<ConsoleNote
      * Returns all the registered {@link ConsoleAnnotationDescriptor} descriptors.
      */
     public static DescriptorExtensionList<ConsoleNote<?>,ConsoleAnnotationDescriptor> all() {
-        return (DescriptorExtensionList) Jenkins.getInstance().getDescriptorList(ConsoleNote.class);
+        return (DescriptorExtensionList) Jenkins.get().getDescriptorList(ConsoleNote.class);
     }
 }

--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -165,7 +165,7 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
     public abstract ConsoleAnnotator annotate(T context, MarkupText text, int charPos);
 
     public ConsoleAnnotationDescriptor getDescriptor() {
-        return (ConsoleAnnotationDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (ConsoleAnnotationDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -270,7 +270,7 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
                 }
             }
 
-            Jenkins jenkins = Jenkins.getInstance();
+            Jenkins jenkins = Jenkins.get();
             try (ObjectInputStream ois = new ObjectInputStreamEx(new GZIPInputStream(new ByteArrayInputStream(buf)),
                     jenkins != null ? jenkins.pluginManager.uberClassLoader : ConsoleNote.class.getClassLoader(),
                     ClassFilter.DEFAULT)) {

--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -66,7 +66,7 @@ public class HyperlinkNote extends ConsoleNote {
                 url = req.getContextPath()+url;
             } else {
                 // otherwise presumably this is rendered for e-mails and other non-HTTP stuff
-                url = Jenkins.getInstance().getRootUrl()+url.substring(1);
+                url = Jenkins.get().getRootUrl()+url.substring(1);
             }
         }
         text.addMarkup(charPos, charPos + length, "<a href='" + url + "'"+extraAttributes()+">", "</a>");

--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -50,7 +50,7 @@ public class ModelHyperlinkNote extends HyperlinkNote {
         if (c != null) {
             return encodeTo("/" + c.getUrl(), node.getDisplayName());
         }
-        String nodePath = node == Jenkins.getInstance() ? "(master)" : node.getNodeName();
+        String nodePath = node == Jenkins.get() ? "(master)" : node.getNodeName();
         return encodeTo("/computer/" + nodePath, node.getDisplayName());
     }
 

--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
@@ -43,8 +43,8 @@ public class HudsonHomeDiskUsageChecker extends PeriodicWork {
     }
 
     protected void doRun() {
-            long free = Jenkins.getInstance().getRootDir().getUsableSpace();
-            long total = Jenkins.getInstance().getRootDir().getTotalSpace();
+            long free = Jenkins.get().getRootDir().getUsableSpace();
+            long total = Jenkins.get().getRootDir().getTotalSpace();
             if(free<=0 || total<=0) {
                 // information unavailable. pointless to try.
                 LOGGER.info("JENKINS_HOME disk usage information isn't available. aborting to monitor");

--- a/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
@@ -68,7 +68,7 @@ public class NullIdDescriptorMonitor extends AdministrativeMonitor {
 
     @Initializer(after=EXTENSIONS_AUGMENTED)
     public void verify() {
-        Jenkins h = Jenkins.getInstance();
+        Jenkins h = Jenkins.get();
         for (Descriptor d : h.getExtensionList(Descriptor.class)) {
             PluginWrapper p = h.getPluginManager().whichPlugin(d.getClass());
             String id;

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -117,7 +117,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
     }
 
     private static void remove(Saveable obj, boolean isDelete) {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         OldDataMonitor odm = get(j);
         SecurityContext oldContext = ACL.impersonate(ACL.SYSTEM);
         try {
@@ -166,7 +166,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
      * @param version Hudson release when the data structure changed.
      */
     public static void report(Saveable obj, String version) {
-        OldDataMonitor odm = get(Jenkins.getInstance());
+        OldDataMonitor odm = get(Jenkins.get());
         try {
             SaveableReference ref = referTo(obj);
             while (true) {
@@ -395,7 +395,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
     private static SaveableReference referTo(Saveable s) {
         if (s instanceof Run) {
             Job parent = ((Run) s).getParent();
-            if (Jenkins.getInstance().getItemByFullName(parent.getFullName()) == parent) {
+            if (Jenkins.get().getItemByFullName(parent.getFullName()) == parent) {
                 return new RunSaveableReference((Run) s);
             }
         }

--- a/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
@@ -64,7 +64,7 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
 
     public HttpResponse doTest() {
         String referer = Stapler.getCurrentRequest().getReferer();
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         // May need to send an absolute URL, since handling of HttpRedirect with a relative URL does not currently honor X-Forwarded-Proto/Port at all.
         String redirect = j.getRootUrl() + "administrativeMonitor/" + id + "/testForReverseProxySetup/" + (referer != null ? Util.rawEncode(referer) : "NO-REFERER") + "/";
         LOGGER.log(Level.FINE, "coming from {0} and redirecting to {1}", new Object[] {referer, redirect});
@@ -73,7 +73,7 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
 
     @StaplerDispatchable
     public void getTestForReverseProxySetup(String rest) {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         String inferred = j.getRootUrlFromRequest() + "manage";
         // TODO this could also verify that j.getRootUrl() has been properly configured, and send a different message if not
         if (rest.startsWith(inferred)) { // not using equals due to JENKINS-24014

--- a/core/src/main/java/hudson/diagnosis/TooManyJobsButNoView.java
+++ b/core/src/main/java/hudson/diagnosis/TooManyJobsButNoView.java
@@ -50,7 +50,7 @@ public class TooManyJobsButNoView extends AdministrativeMonitor {
     }
 
     public boolean isActivated() {
-        Jenkins h = Jenkins.getInstance();
+        Jenkins h = Jenkins.get();
         return h.getViews().size()==1 && h.getItemMap().size()> THRESHOLD;
     }
 

--- a/core/src/main/java/hudson/fsp/WorkspaceSnapshotSCM.java
+++ b/core/src/main/java/hudson/fsp/WorkspaceSnapshotSCM.java
@@ -94,7 +94,7 @@ public class WorkspaceSnapshotSCM extends SCM {
      * @return never null.
      */
     public Snapshot resolve() throws ResolvedFailedException {
-        Jenkins h = Jenkins.getInstance();
+        Jenkins h = Jenkins.get();
         AbstractProject<?,?> job = h.getItemByFullName(jobName, AbstractProject.class);
         if(job==null) {
             if(h.getItemByFullName(jobName)==null) {

--- a/core/src/main/java/hudson/init/TaskMethodFinder.java
+++ b/core/src/main/java/hudson/init/TaskMethodFinder.java
@@ -115,7 +115,7 @@ abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
      * Determines the parameter injection of the initialization method.
      */
     private Object lookUp(Class<?> type) {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         assert j != null : "This method is only invoked after the Jenkins singleton instance has been set";
         if (type==Jenkins.class || type==Hudson.class)
             return j;

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -61,7 +61,7 @@ public abstract class Lifecycle implements ExtensionPoint {
             String p = SystemProperties.getString("hudson.lifecycle");
             if(p!=null) {
                 try {
-                    ClassLoader cl = Jenkins.getInstance().getPluginManager().uberClassLoader;
+                    ClassLoader cl = Jenkins.get().getPluginManager().uberClassLoader;
                     instance = (Lifecycle)cl.loadClass(p).newInstance();
                 } catch (InstantiationException e) {
                     InstantiationError x = new InstantiationError(e.getMessage());

--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -111,7 +111,7 @@ public class WindowsInstallerLink extends ManagementLink {
      */
     @RequirePOST
     public void doDoInstall(StaplerRequest req, StaplerResponse rsp, @QueryParameter("dir") String _dir) throws IOException, ServletException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         if(installationDir!=null) {
             // installation already complete
@@ -173,7 +173,7 @@ public class WindowsInstallerLink extends ManagementLink {
 
     @RequirePOST
     public void doRestart(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         if(installationDir==null) {
             // if the user reloads the page after Hudson has restarted,
@@ -184,7 +184,7 @@ public class WindowsInstallerLink extends ManagementLink {
         }
 
         rsp.forward(this,"_restart",req);
-        final File oldRoot = Jenkins.getInstance().getRootDir();
+        final File oldRoot = Jenkins.get().getRootDir();
 
         // initiate an orderly shutdown after we finished serving this request
         new Thread("terminator") {
@@ -228,7 +228,7 @@ public class WindowsInstallerLink extends ManagementLink {
                         }
                     });
 
-                    Jenkins.getInstance().cleanUp();
+                    Jenkins.get().cleanUp();
                     System.exit(0);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
@@ -247,7 +247,7 @@ public class WindowsInstallerLink extends ManagementLink {
     protected final void sendError(String message, StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
         req.setAttribute("message",message);
         req.setAttribute("pre",true);
-        rsp.forward(Jenkins.getInstance(),"error",req);
+        rsp.forward(Jenkins.get(),"error",req);
     }
 
     /**
@@ -269,7 +269,7 @@ public class WindowsInstallerLink extends ManagementLink {
 
             // TODO possibly now unused (JNLP installation mode is long gone):
             if(SystemProperties.getString(WindowsInstallerLink.class.getName()+".prominent")!=null)
-                Jenkins.getInstance().getActions().add(link);
+                Jenkins.get().getActions().add(link);
 
             return link;
         }

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -153,7 +153,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
             baseDir = new File(baseEnv);
         } else {
             LOGGER.log(Level.WARNING, "Could not find environment variable 'BASE' for Jenkins base directory. Falling back to JENKINS_HOME");
-            baseDir = Jenkins.getInstance().getRootDir();
+            baseDir = Jenkins.get().getRootDir();
         }
         return baseDir;
     }

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -275,7 +275,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             return null;
         }
         void broadcast() {
-            for (Computer c : Jenkins.getInstance().getComputers()) {
+            for (Computer c : Jenkins.get().getComputers()) {
                 if (c.getName().length() > 0) { // i.e. not master
                     VirtualChannel ch = c.getChannel();
                     if (ch != null) {
@@ -292,7 +292,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     @Extension @Restricted(NoExternalUse.class) public static final class ComputerLogInitializer extends ComputerListener {
         @Override public void preOnline(Computer c, Channel channel, FilePath root, TaskListener listener) throws IOException, InterruptedException {
-            for (LogRecorder recorder : Jenkins.getInstance().getLog().logRecorders.values()) {
+            for (LogRecorder recorder : Jenkins.get().getLog().logRecorders.values()) {
                 for (Target t : recorder.targets) {
                     channel.call(new SetLevel(t.name, t.getLevel()));
                 }
@@ -320,7 +320,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     }
 
     public LogRecorderManager getParent() {
-        return Jenkins.getInstance().getLog();
+        return Jenkins.get().getLog();
     }
 
     /**
@@ -426,7 +426,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
                 return COLL.compare(c1.getDisplayName(), c2.getDisplayName());
             }
         });
-        for (Computer c : Jenkins.getInstance().getComputers()) {
+        for (Computer c : Jenkins.get().getComputers()) {
             if (c.getName().length() == 0) {
                 continue; // master
             }

--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -87,7 +87,7 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
     }
 
     static File configDir() {
-        return new File(Jenkins.getInstance().getRootDir(), "log");
+        return new File(Jenkins.get().getRootDir(), "log");
     }
 
     /**
@@ -135,7 +135,7 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE")
     @RequirePOST
     public HttpResponse doConfigLogger(@QueryParameter String name, @QueryParameter String level) {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         Level lv;
         if(level.equals("inherit"))
             lv = null;
@@ -206,7 +206,7 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         }
         return this;
     }

--- a/core/src/main/java/hudson/markup/MarkupFormatterDescriptor.java
+++ b/core/src/main/java/hudson/markup/MarkupFormatterDescriptor.java
@@ -38,7 +38,7 @@ public abstract class MarkupFormatterDescriptor extends Descriptor<MarkupFormatt
      * Returns all the registered {@link MarkupFormatterDescriptor}s.
      */
     public static DescriptorExtensionList<MarkupFormatter,MarkupFormatterDescriptor> all() {
-        return Jenkins.getInstance().
+        return Jenkins.get().
                 getDescriptorList(MarkupFormatter.class);
     }
 }

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -207,9 +207,9 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      */
     public @CheckForNull Node getBuiltOn() {
         if (builtOn==null || builtOn.equals(""))
-            return Jenkins.getInstance();
+            return Jenkins.get();
         else
-            return Jenkins.getInstance().getNode(builtOn);
+            return Jenkins.get().getNode(builtOn);
     }
 
     /**
@@ -460,7 +460,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             this.listener = listener;
 
             launcher = createLauncher(listener);
-            if (!Jenkins.getInstance().getNodes().isEmpty()) {
+            if (!Jenkins.get().getNodes().isEmpty()) {
                 if (node instanceof Jenkins) {
                     listener.getLogger().print(Messages.AbstractBuild_BuildingOnMaster());
                 } else {
@@ -545,7 +545,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 }
             }
 
-            for (NodeProperty nodeProperty: Jenkins.getInstance().getGlobalNodeProperties()) {
+            for (NodeProperty nodeProperty: Jenkins.get().getGlobalNodeProperties()) {
                 Environment environment = nodeProperty.setUp(AbstractBuild.this, l, listener);
                 if (environment != null) {
                     buildEnvironments.add(environment);
@@ -1001,7 +1001,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     @Deprecated
     public Action getTestResultAction() {
         try {
-            return getAction(Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass("hudson.tasks.test.AbstractTestResultAction").asSubclass(Action.class));
+            return getAction(Jenkins.get().getPluginManager().uberClassLoader.loadClass("hudson.tasks.test.AbstractTestResultAction").asSubclass(Action.class));
         } catch (ClassNotFoundException x) {
             return null;
         }
@@ -1013,7 +1013,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     @Deprecated
     public Action getAggregatedTestResultAction() {
         try {
-            return getAction(Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass("hudson.tasks.test.AggregatedTestResultAction").asSubclass(Action.class));
+            return getAction(Jenkins.get().getPluginManager().uberClassLoader.loadClass("hudson.tasks.test.AggregatedTestResultAction").asSubclass(Action.class));
         } catch (ClassNotFoundException x) {
             return null;
         }

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -131,7 +131,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
             }
         } else {
             // we always need Computer for the master as a fallback in case there's no other Computer.
-            if(n.getNumExecutors()>0 || n==Jenkins.getInstance()) {
+            if(n.getNumExecutors()>0 || n==Jenkins.get()) {
                 try {
                     c = n.createComputer();
                 } catch(RuntimeException ex) { // Just in case there is a bogus extension

--- a/core/src/main/java/hudson/model/AbstractDescribableImpl.java
+++ b/core/src/main/java/hudson/model/AbstractDescribableImpl.java
@@ -39,7 +39,7 @@ public abstract class AbstractDescribableImpl<T extends AbstractDescribableImpl<
      */
     @Override
     public Descriptor<T> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
 }

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -589,7 +589,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      * Returns the {@link ACL} for this object.
      */
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.get().getAuthorizationStrategy().getACL(this);
     }
 
     /**
@@ -713,7 +713,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                 // the 15 second delay for every child item). This happens after queue cancellation, so will be
                 // a complete set of builds in flight
                 Map<Executor, Queue.Executable> buildsInProgress = new LinkedHashMap<>();
-                for (Computer c : Jenkins.getInstance().getComputers()) {
+                for (Computer c : Jenkins.get().getComputers()) {
                     for (Executor e : c.getAllExecutors()) {
                         final WorkUnit workUnit = e.getCurrentWorkUnit();
                         final Executable executable = workUnit != null ? workUnit.getExecutable() : null;
@@ -780,7 +780,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
             }
         }
         getParent().onDeleted(AbstractItem.this);
-        Jenkins.getInstance().rebuildDependencyGraphAsync();
+        Jenkins.get().rebuildDependencyGraphAsync();
     }
 
     /**
@@ -882,7 +882,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                     return null;
                 }
             });
-            Jenkins.getInstance().rebuildDependencyGraphAsync();
+            Jenkins.get().rebuildDependencyGraphAsync();
 
             // if everything went well, commit this new version
             out.commit();
@@ -915,7 +915,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                 return null;
             }
         });
-        Jenkins.getInstance().rebuildDependencyGraphAsync();
+        Jenkins.get().rebuildDependencyGraphAsync();
 
         SaveableListener.fireOnChange(this, getConfigFile());
     }
@@ -961,9 +961,9 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     public static AbstractItem resolveForCLI(
             @Argument(required=true,metaVar="NAME",usage="Item name") String name) throws CmdLineException {
         // TODO can this (and its pseudo-override in AbstractProject) share code with GenericItemOptionHandler, used for explicit CLICommand’s rather than CLIMethod’s?
-        AbstractItem item = Jenkins.getInstance().getItemByFullName(name, AbstractItem.class);
+        AbstractItem item = Jenkins.get().getItemByFullName(name, AbstractItem.class);
         if (item==null) {
-            AbstractItem project = Items.findNearest(AbstractItem.class, name, Jenkins.getInstance());
+            AbstractItem project = Items.findNearest(AbstractItem.class, name, Jenkins.get());
             throw new CmdLineException(null, project == null ? Messages.AbstractItem_NoSuchJobExistsWithoutSuggestion(name)
                     : Messages.AbstractItem_NoSuchJobExists(name, project.getFullName()));
         }

--- a/core/src/main/java/hudson/model/AutoCompletionCandidates.java
+++ b/core/src/main/java/hudson/model/AutoCompletionCandidates.java
@@ -154,12 +154,12 @@ public class AutoCompletionCandidates implements HttpResponse {
             }
         }
 
-        if (container==null || container==Jenkins.getInstance()) {
-            new Visitor("").onItemGroup(Jenkins.getInstance());
+        if (container==null || container==Jenkins.get()) {
+            new Visitor("").onItemGroup(Jenkins.get());
         } else {
             new Visitor("").onItemGroup(container);
             if (value.startsWith("/"))
-                new Visitor("/").onItemGroup(Jenkins.getInstance());
+                new Visitor("/").onItemGroup(Jenkins.get());
 
             for ( String p="../"; value.startsWith(p); p+="../") {
                 container = ((Item)container).getParent();

--- a/core/src/main/java/hudson/model/BuildAuthorizationToken.java
+++ b/core/src/main/java/hudson/model/BuildAuthorizationToken.java
@@ -68,7 +68,7 @@ public final class BuildAuthorizationToken {
     }
 
     public static void checkPermission(Job<?,?> project, BuildAuthorizationToken token, StaplerRequest req, StaplerResponse rsp) throws IOException {
-        if (!Jenkins.getInstance().isUseSecurity())
+        if (!Jenkins.get().isUseSecurity())
             return;    // everyone is authorized
 
         if(token!=null && token.token != null) {

--- a/core/src/main/java/hudson/model/BuildStepListener.java
+++ b/core/src/main/java/hudson/model/BuildStepListener.java
@@ -25,7 +25,7 @@ public abstract class BuildStepListener implements ExtensionPoint {
      * Returns all the registered {@link BuildStepListener}s.
      */
     public static ExtensionList<BuildStepListener> all() {
-        // TODO should have a null-safe version when Jenkins.get() is null; would require changes in ExtensionList
+        // TODO should have a null-safe version when Jenkins.getInstanceOrNull() is null; would require changes in ExtensionList
         return ExtensionList.lookup(BuildStepListener.class);
     }
 }

--- a/core/src/main/java/hudson/model/BuildStepListener.java
+++ b/core/src/main/java/hudson/model/BuildStepListener.java
@@ -25,7 +25,7 @@ public abstract class BuildStepListener implements ExtensionPoint {
      * Returns all the registered {@link BuildStepListener}s.
      */
     public static ExtensionList<BuildStepListener> all() {
-        // TODO should have a null-safe version when Jenkins.getInstance() is null; would require changes in ExtensionList
+        // TODO should have a null-safe version when Jenkins.get() is null; would require changes in ExtensionList
         return ExtensionList.lookup(BuildStepListener.class);
     }
 }

--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -191,7 +191,7 @@ public abstract class Cause {
 
         @Override
         public void onLoad(@Nonnull Job<?,?> _job, int _buildNumber) {
-            Item i = Jenkins.getInstance().getItemByFullName(this.upstreamProject);
+            Item i = Jenkins.get().getItemByFullName(this.upstreamProject);
             if (!(i instanceof Job)) {
                 // cannot initialize upstream causes
                 return;
@@ -275,7 +275,7 @@ public abstract class Cause {
          * @since 1.505
          */
         public @CheckForNull Run<?,?> getUpstreamRun() {
-            Job<?,?> job = Jenkins.getInstance().getItemByFullName(upstreamProject, Job.class);
+            Job<?,?> job = Jenkins.get().getItemByFullName(upstreamProject, Job.class);
             return job != null ? job.getBuildByNumber(upstreamBuild) : null;
         }
 
@@ -486,7 +486,7 @@ public abstract class Cause {
         public String getShortDescription() {
             if(note != null) {
                 try {
-                    return Messages.Cause_RemoteCause_ShortDescriptionWithNote(addr, Jenkins.getInstance().getMarkupFormatter().translate(note));
+                    return Messages.Cause_RemoteCause_ShortDescriptionWithNote(addr, Jenkins.get().getMarkupFormatter().translate(note));
                 } catch (IOException x) {
                     // ignore
                 }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -299,7 +299,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * @since 1.613
      */
     protected @Nonnull File getLogDir() {
-        File dir = new File(Jenkins.getInstance().getRootDir(),"logs/slaves/"+nodeName);
+        File dir = new File(Jenkins.get().getRootDir(),"logs/slaves/"+nodeName);
         if (!dir.exists() && !dir.mkdirs()) {
             LOGGER.severe("Failed to create agent log directory " + dir.getAbsolutePath());
         }
@@ -329,7 +329,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.get().getAuthorizationStrategy().getACL(this);
     }
 
     /**
@@ -592,7 +592,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
     @Exported
     public LoadStatistics getLoadStatistics() {
-        return LabelAtom.get(nodeName != null ? nodeName : Jenkins.getInstance().getSelfLabel().toString()).loadStatistics;
+        return LabelAtom.get(nodeName != null ? nodeName : Jenkins.get().getSelfLabel().toString()).loadStatistics;
     }
 
     public BuildTimelineWidget getTimeline() {
@@ -791,7 +791,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     public RunList getBuilds() {
-        return RunList.fromJobs((Iterable)Jenkins.getInstance().allItems(Job.class)).node(getNode());
+        return RunList.fromJobs((Iterable)Jenkins.get().allItems(Job.class)).node(getNode());
     }
 
     /**
@@ -1064,7 +1064,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     public final long getDemandStartMilliseconds() {
         long firstDemand = Long.MAX_VALUE;
-        for (Queue.BuildableItem item : Jenkins.getInstance().getQueue().getBuildableItems(this)) {
+        for (Queue.BuildableItem item : Jenkins.get().getQueue().getBuildableItems(this)) {
             firstDemand = Math.min(item.buildableStartMilliseconds, firstDemand);
         }
         return firstDemand;
@@ -1203,7 +1203,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         Node node = getNode();
         if (node==null)     return env; // bail out
 
-        for (NodeProperty nodeProperty: Jenkins.getInstance().getGlobalNodeProperties()) {
+        for (NodeProperty nodeProperty: Jenkins.get().getGlobalNodeProperties()) {
             nodeProperty.buildEnvVars(env,listener);
         }
 
@@ -1212,7 +1212,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
 
         // TODO: hmm, they don't really belong
-        String rootUrl = Jenkins.getInstance().getRootUrl();
+        String rootUrl = Jenkins.get().getRootUrl();
         if(rootUrl!=null) {
             env.put("HUDSON_URL", rootUrl); // Legacy.
             env.put("JENKINS_URL", rootUrl);
@@ -1487,7 +1487,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
 
         Node result = node.reconfigure(req, req.getSubmittedForm());
-        Jenkins.getInstance().getNodesObject().replaceNode(this.getNode(), result);
+        Jenkins.get().getNodesObject().replaceNode(this.getNode(), result);
 
         // take the user back to the agent top page.
         rsp.sendRedirect2("../" + result.getNodeName() + '/');
@@ -1529,7 +1529,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     public void updateByXml(final InputStream source) throws IOException, ServletException {
         checkPermission(CONFIGURE);
         Node result = (Node)Jenkins.XSTREAM2.fromXML(source);
-        Jenkins.getInstance().getNodesObject().replaceNode(this.getNode(), result);
+        Jenkins.get().getNodesObject().replaceNode(this.getNode(), result);
     }
 
     /**
@@ -1540,9 +1540,9 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         checkPermission(DELETE);
         Node node = getNode();
         if (node != null) {
-            Jenkins.getInstance().removeNode(node);
+            Jenkins.get().removeNode(node);
         } else {
-            AbstractCIBase app = Jenkins.getInstance();
+            AbstractCIBase app = Jenkins.get();
             app.removeComputer(this);
         }
         return new HttpRedirect("..");
@@ -1603,7 +1603,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     @CLIResolver
     public static Computer resolveForCLI(
             @Argument(required=true,metaVar="NAME",usage="Agent name, or empty string for master") String name) throws CmdLineException {
-        Jenkins h = Jenkins.getInstance();
+        Jenkins h = Jenkins.get();
         Computer item = h.getComputer(name);
         if (item==null) {
             List<String> names = ComputerSet.getComputerNames();
@@ -1625,7 +1625,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     @Initializer
     public static void relocateOldLogs() {
-        relocateOldLogs(Jenkins.getInstance().getRootDir());
+        relocateOldLogs(Jenkins.get().getRootDir());
     }
 
     /*package*/ static void relocateOldLogs(File dir) {

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -103,7 +103,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
     @Exported(name="computer",inline=true)
     public Computer[] get_all() {
-        return Jenkins.getInstance().getComputers();
+        return Jenkins.get().getComputers();
     }
 
     public ContextMenu doChildrenContextMenu(StaplerRequest request, StaplerResponse response) throws Exception {
@@ -142,7 +142,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     public List<String> get_slaveNames() {
         return new AbstractList<String>() {
-            final List<Node> nodes = Jenkins.getInstance().getNodes();
+            final List<Node> nodes = Jenkins.get().getNodes();
 
             public String get(int index) {
                 return nodes.get(index).getNodeName();
@@ -198,12 +198,12 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     }
 
     public Computer getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
-        return Jenkins.getInstance().getComputer(token);
+        return Jenkins.get().getComputer(token);
     }
 
     @RequirePOST
     public void do_launchAll(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         for(Computer c : get_all()) {
             if(c.isLaunchSupported())
@@ -219,7 +219,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     @RequirePOST
     public void doUpdateNow( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         
         for (NodeMonitor nodeMonitor : NodeMonitor.getAll()) {
             Thread t = nodeMonitor.triggerUpdate();
@@ -238,7 +238,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     public synchronized void doCreateItem( StaplerRequest req, StaplerResponse rsp,
                                            @QueryParameter String name, @QueryParameter String mode,
                                            @QueryParameter String from ) throws IOException, ServletException {
-        final Jenkins app = Jenkins.getInstance();
+        final Jenkins app = Jenkins.get();
         app.checkPermission(Computer.CREATE);
 
         if(mode!=null && mode.equals("copy")) {
@@ -288,7 +288,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     public synchronized void doDoCreateItem( StaplerRequest req, StaplerResponse rsp,
                                            @QueryParameter String name,
                                            @QueryParameter String type ) throws IOException, ServletException, FormException {
-        final Jenkins app = Jenkins.getInstance();
+        final Jenkins app = Jenkins.get();
         app.checkPermission(Computer.CREATE);
         String fixedName = Util.fixEmptyAndTrim(name);
         checkName(fixedName);
@@ -315,7 +315,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
         name = name.trim();
         Jenkins.checkGoodName(name);
 
-        if(Jenkins.getInstance().getNode(name)!=null)
+        if(Jenkins.get().getNode(name)!=null)
             throw new Failure(Messages.ComputerSet_SlaveAlreadyExists(name));
 
         // looks good
@@ -326,7 +326,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      * Makes sure that the given name is good as an agent name.
      */
     public FormValidation doCheckName(@QueryParameter String value) throws IOException, ServletException {
-        Jenkins.getInstance().checkPermission(Computer.CREATE);
+        Jenkins.get().checkPermission(Computer.CREATE);
 
         if(Util.fixEmpty(value)==null)
             return FormValidation.ok();
@@ -346,7 +346,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     public synchronized HttpResponse doConfigSubmit( StaplerRequest req) throws IOException, ServletException, FormException {
         BulkChange bc = new BulkChange(MONITORS_OWNER);
         try {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             monitors.rebuild(req,req.getSubmittedForm(),getNodeMonitorDescriptors());
 
             // add in the rest of instances are ignored instances
@@ -372,7 +372,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      * {@link NodeMonitor}s are persisted in this file.
      */
     private static XmlFile getConfigFile() {
-        return new XmlFile(new File(Jenkins.getInstance().getRootDir(),"nodeMonitors.xml"));
+        return new XmlFile(new File(Jenkins.get().getRootDir(),"nodeMonitors.xml"));
     }
 
     public Api getApi() {
@@ -380,7 +380,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     }
 
     public Descriptor<ComputerSet> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(ComputerSet.class);
+        return Jenkins.get().getDescriptorOrDie(ComputerSet.class);
     }
 
     @Extension
@@ -391,7 +391,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
         public AutoCompletionCandidates doAutoCompleteCopyNewItemFrom(@QueryParameter final String value) {
             final AutoCompletionCandidates r = new AutoCompletionCandidates();
 
-            for (Node n : Jenkins.getInstance().getNodes()) {
+            for (Node n : Jenkins.get().getNodes()) {
                 if (n.getNodeName().startsWith(value))
                     r.add(n.getNodeName());
             }
@@ -422,7 +422,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     @Nonnull
     public static List<String> getComputerNames() {
         final ArrayList<String> names = new ArrayList<>();
-        for (Computer c : Jenkins.getInstance().getComputers()) {
+        for (Computer c : Jenkins.get().getComputers()) {
             if (!c.getName().isEmpty()) {
                 names.add(c.getName());
             }

--- a/core/src/main/java/hudson/model/DependencyGraph.java
+++ b/core/src/main/java/hudson/model/DependencyGraph.java
@@ -91,7 +91,7 @@ public class DependencyGraph implements Comparator<AbstractProject> {
         SecurityContext saveCtx = ACL.impersonate(ACL.SYSTEM);
         try {
             this.computationalData = new HashMap<>();
-            for( AbstractProject p : Jenkins.getInstance().allItems(AbstractProject.class) )
+            for( AbstractProject p : Jenkins.get().allItems(AbstractProject.class) )
                 p.buildDependencyGraph(this);
 
             forward = finalize(forward);

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -199,7 +199,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
          * Returns {@link Descriptor} whose 'clazz' is the same as {@link #getItemType() the item type}.
          */
         public Descriptor getItemTypeDescriptor() {
-            return Jenkins.getInstance().getDescriptor(getItemType());
+            return Jenkins.get().getDescriptor(getItemType());
         }
 
         public Descriptor getItemTypeDescriptorOrDie() {
@@ -207,7 +207,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
             if (it == null) {
                 throw new AssertionError(clazz + " is not an array/collection type in " + displayName + ". See https://jenkins.io/redirect/developer/class-is-missing-descriptor");
             }
-            Descriptor d = Jenkins.getInstance().getDescriptor(it);
+            Descriptor d = Jenkins.get().getDescriptor(it);
             if (d==null)
                 throw new AssertionError(it +" is missing its descriptor in "+displayName+". See https://jenkins.io/redirect/developer/class-is-missing-descriptor");
             return d;
@@ -217,14 +217,14 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
          * Returns all the descriptors that produce types assignable to the property type.
          */
         public List<? extends Descriptor> getApplicableDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(clazz);
+            return Jenkins.get().getDescriptorList(clazz);
         }
 
         /**
          * Returns all the descriptors that produce types assignable to the item type for a collection property.
          */
         public List<? extends Descriptor> getApplicableItemDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(getItemType());
+            return Jenkins.get().getDescriptorList(getItemType());
         }
     }
 
@@ -246,7 +246,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
 
         private String resolve() {
             // the resolution has to be deferred to avoid ordering issue among descriptor registrations.
-            return Jenkins.getInstance().getDescriptor(owner).getHelpFile(fieldNameToRedirectTo);
+            return Jenkins.get().getDescriptor(owner).getHelpFile(fieldNameToRedirectTo);
         }
     }
 
@@ -856,7 +856,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
 
     protected List<String> getPossibleViewNames(String baseName) {
         List<String> names = new ArrayList<>();
-        for (Facet f : WebApp.get(Jenkins.getInstance().servletContext).facets) {
+        for (Facet f : WebApp.get(Jenkins.get().servletContext).facets) {
             if (f instanceof JellyCompatibleFacet) {
                 JellyCompatibleFacet jcf = (JellyCompatibleFacet) f;
                 for (String ext : jcf.getScriptExtensions())
@@ -901,7 +901,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
     }
 
     protected XmlFile getConfigFile() {
-        return new XmlFile(new File(Jenkins.getInstance().getRootDir(),getId()+".xml"));
+        return new XmlFile(new File(Jenkins.get().getRootDir(),getId()+".xml"));
     }
 
     /**
@@ -911,7 +911,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      *      null to indicate that this descriptor came from the core.
      */
     protected PluginWrapper getPlugin() {
-        return Jenkins.getInstance().getPluginManager().whichPlugin(clazz);
+        return Jenkins.get().getPluginManager().whichPlugin(clazz);
     }
 
     /**

--- a/core/src/main/java/hudson/model/DescriptorByNameOwner.java
+++ b/core/src/main/java/hudson/model/DescriptorByNameOwner.java
@@ -49,6 +49,6 @@ public interface DescriptorByNameOwner extends ModelObject {
      *      Either {@link Descriptor#getId()} (recommended) or the short name.
      */
     default Descriptor getDescriptorByName(String id) {
-        return Jenkins.getInstance().getDescriptorByName(id);
+        return Jenkins.get().getDescriptorByName(id);
     }
 }

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -310,7 +310,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         if(rest.equals("*fingerprint*")) {
             InputStream fingerprintInput = baseFile.open();
             try {
-                rsp.forward(Jenkins.getInstance().getFingerprint(Util.getDigestOf(fingerprintInput)), "/", req);
+                rsp.forward(Jenkins.get().getFingerprint(Util.getDigestOf(fingerprintInput)), "/", req);
             } finally {
                 fingerprintInput.close();
             }

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -89,7 +89,7 @@ public class DownloadService extends PageDecorator {
         if (doesNotSupportPostMessage())  return "";
 
         StringBuilder buf = new StringBuilder();
-        if(Jenkins.getInstance().hasPermission(Jenkins.READ)) {
+        if(Jenkins.get().hasPermission(Jenkins.READ)) {
             long now = System.currentTimeMillis();
             for (Downloadable d : Downloadable.all()) {
                 if(d.getDue()<now && d.lastAttempt+TimeUnit.SECONDS.toMillis(10)<now) {
@@ -302,7 +302,7 @@ public class DownloadService extends PageDecorator {
          * URL to download.
          */
         public String getUrl() {
-            return Jenkins.getInstance().getUpdateCenter().getDefaultBaseUrl()+"updates/"+url;
+            return Jenkins.get().getUpdateCenter().getDefaultBaseUrl()+"updates/"+url;
         }
 
         /**
@@ -337,7 +337,7 @@ public class DownloadService extends PageDecorator {
          * This is where the retrieved file will be stored.
          */
         public TextFile getDataFile() {
-            return new TextFile(new File(Jenkins.getInstance().getRootDir(),"updates/"+id));
+            return new TextFile(new File(Jenkins.get().getRootDir(),"updates/"+id));
         }
 
         /**

--- a/core/src/main/java/hudson/model/Failure.java
+++ b/core/src/main/java/hudson/model/Failure.java
@@ -67,8 +67,8 @@ public class Failure extends RuntimeException implements HttpResponse {
         if(pre)
             req.setAttribute("pre",true);
         if (node instanceof AbstractItem) // Maintain ancestors
-            rsp.forward(Jenkins.getInstance(), ((AbstractItem)node).getUrl() + "error", req);
+            rsp.forward(Jenkins.get(), ((AbstractItem)node).getUrl() + "error", req);
         else
-            rsp.forward(node instanceof AbstractModelObject ? node : Jenkins.getInstance() ,"error", req);
+            rsp.forward(node instanceof AbstractModelObject ? node : Jenkins.get() ,"error", req);
     }
 }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -129,7 +129,7 @@ public class Fingerprint implements ModelObject, Saveable {
         private boolean hasPermissionToDiscoverBuild() {
             // We expose the data to Jenkins administrators in order to
             // let them manage the data for deleted jobs (also works for SYSTEM)
-            final Jenkins instance = Jenkins.getInstance();
+            final Jenkins instance = Jenkins.get();
             if (instance.hasPermission(Jenkins.ADMINISTER)) {
                 return true;
             }
@@ -149,7 +149,7 @@ public class Fingerprint implements ModelObject, Saveable {
          */
         @WithBridgeMethods(value=AbstractProject.class, castRequired=true)
         public Job<?,?> getJob() {
-            return Jenkins.getInstance().getItemByFullName(name, Job.class);
+            return Jenkins.get().getItemByFullName(name, Job.class);
         }
 
         /**
@@ -201,7 +201,7 @@ public class Fingerprint implements ModelObject, Saveable {
          * belongs to MavenModuleSet. 
          */
         public boolean belongsTo(Job job) {
-            Item p = Jenkins.getInstance().getItemByFullName(name);
+            Item p = Jenkins.get().getItemByFullName(name);
             while(p!=null) {
                 if(p==job)
                     return true;
@@ -828,7 +828,7 @@ public class Fingerprint implements ModelObject, Saveable {
         }
         private void locationChanged(Item item, String oldName, String newName) {
             if (item instanceof Job) {
-                Job p = Jenkins.getInstance().getItemByFullName(newName, Job.class);
+                Job p = Jenkins.get().getItemByFullName(newName, Job.class);
                 if (p != null) {
                     RunList<? extends Run> builds = p.getBuilds();
                     for (Run build : builds) {
@@ -993,7 +993,7 @@ public class Fingerprint implements ModelObject, Saveable {
     @Exported(name="usage")
     public @Nonnull List<RangeItem> _getUsages() {
         List<RangeItem> r = new ArrayList<>();
-        final Jenkins instance = Jenkins.getInstance();
+        final Jenkins instance = Jenkins.get();
         for (Entry<String, RangeSet> e : usages.entrySet()) {
             final String itemName = e.getKey();
             if (instance.hasPermission(Jenkins.ADMINISTER) || canDiscoverItem(itemName)) {
@@ -1060,7 +1060,7 @@ public class Fingerprint implements ModelObject, Saveable {
             return true;
 
         for (Entry<String,RangeSet> e : usages.entrySet()) {
-            Job j = Jenkins.getInstance().getItemByFullName(e.getKey(),Job.class);
+            Job j = Jenkins.get().getItemByFullName(e.getKey(),Job.class);
             if(j==null)
                 continue;
 
@@ -1087,7 +1087,7 @@ public class Fingerprint implements ModelObject, Saveable {
         boolean modified = false;
 
         for (Entry<String,RangeSet> e : new Hashtable<>(usages).entrySet()) {// copy because we mutate
-            Job j = Jenkins.getInstance().getItemByFullName(e.getKey(),Job.class);
+            Job j = Jenkins.get().getItemByFullName(e.getKey(),Job.class);
             if(j==null) {// no such job any more. recycle the record
                 modified = true;
                 usages.remove(e.getKey());
@@ -1349,7 +1349,7 @@ public class Fingerprint implements ModelObject, Saveable {
      */
     private static @Nonnull File getFingerprintFile(@Nonnull byte[] md5sum) {
         assert md5sum.length==16;
-        return new File( Jenkins.getInstance().getRootDir(),
+        return new File( Jenkins.get().getRootDir(),
             "fingerprints/"+ Util.toHexString(md5sum,0,1)+'/'+Util.toHexString(md5sum,1,1)+'/'+Util.toHexString(md5sum,2,md5sum.length-2)+".xml");
     }
 
@@ -1429,7 +1429,7 @@ public class Fingerprint implements ModelObject, Saveable {
      * @return {@code true} if the user can discover the item
      */
     private static boolean canDiscoverItem(@Nonnull final String fullName) {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         // Fast check to avoid security context switches
         Item item = null;

--- a/core/src/main/java/hudson/model/FingerprintMap.java
+++ b/core/src/main/java/hudson/model/FingerprintMap.java
@@ -50,7 +50,7 @@ public final class FingerprintMap extends KeyedDataStorage<Fingerprint,Fingerpri
      * Returns true if there's some data in the fingerprint database.
      */
     public boolean isReady() {
-        return new File(Jenkins.getInstance().getRootDir(),"fingerprints").exists();
+        return new File(Jenkins.get().getRootDir(),"fingerprints").exists();
     }
 
     /**

--- a/core/src/main/java/hudson/model/FreeStyleProject.java
+++ b/core/src/main/java/hudson/model/FreeStyleProject.java
@@ -57,7 +57,7 @@ public class FreeStyleProject extends Project<FreeStyleProject,FreeStyleBuild> i
     }
 
     public DescriptorImpl getDescriptor() {
-        return (DescriptorImpl)Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (DescriptorImpl)Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**

--- a/core/src/main/java/hudson/model/Hudson.java
+++ b/core/src/main/java/hudson/model/Hudson.java
@@ -74,7 +74,7 @@ public class Hudson extends Jenkins {
     @CLIResolver
     @Nullable
     public static Hudson getInstance() {
-        return (Hudson)Jenkins.getInstance();
+        return (Hudson)Jenkins.get();
     }
 
     public Hudson(File root, ServletContext context) throws IOException, InterruptedException, ReactorException {
@@ -305,7 +305,7 @@ public class Hudson extends Jenkins {
      */
     @Deprecated
     public static boolean isAdmin() {
-        return Jenkins.getInstance().getACL().hasPermission(ADMINISTER);
+        return Jenkins.get().getACL().hasPermission(ADMINISTER);
     }
 
     /**

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -201,7 +201,7 @@ public interface Item extends PersistenceRoot, SearchableModelObject, AccessCont
      */
     @Deprecated
     default String getAbsoluteUrl() {
-        String r = Jenkins.getInstance().getRootUrl();
+        String r = Jenkins.get().getRootUrl();
         if(r==null)
             throw new IllegalStateException("Root URL isn't configured yet. Cannot compute absolute URL.");
         return Util.encode(r+getUrl());

--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -175,7 +175,7 @@ public abstract class ItemGroupMixIn {
             String from = req.getParameter("from");
 
             // resolve a name to Item
-            Item src = Jenkins.getInstance().getItem(from, parent);
+            Item src = Jenkins.get().getItem(from, parent);
             if(src==null) {
                 if(Util.fixEmpty(from)==null)
                     throw new Failure("Specify which job to copy");
@@ -255,7 +255,7 @@ public abstract class ItemGroupMixIn {
 
         add(result);
         ItemListener.fireOnCopied(src,result);
-        Jenkins.getInstance().rebuildDependencyGraphAsync();
+        Jenkins.get().rebuildDependencyGraphAsync();
 
         return result;
     }
@@ -263,7 +263,7 @@ public abstract class ItemGroupMixIn {
     public synchronized TopLevelItem createProjectFromXML(String name, InputStream xml) throws IOException {
         acl.checkPermission(Item.CREATE);
 
-        Jenkins.getInstance().getProjectNamingStrategy().checkName(name);
+        Jenkins.get().getProjectNamingStrategy().checkName(name);
         Items.verifyItemDoesNotAlreadyExist(parent, name, null);
 
         // place it as config.xml
@@ -287,7 +287,7 @@ public abstract class ItemGroupMixIn {
             add(result);
 
             ItemListener.fireOnCreated(result);
-            Jenkins.getInstance().rebuildDependencyGraphAsync();
+            Jenkins.get().rebuildDependencyGraphAsync();
 
             return result;
         } catch (TransformerException | SAXException e) {
@@ -310,14 +310,14 @@ public abstract class ItemGroupMixIn {
         type.checkApplicableIn(parent);
         acl.getACL().checkCreatePermission(parent, type);
 
-        Jenkins.getInstance().getProjectNamingStrategy().checkName(name);
+        Jenkins.get().getProjectNamingStrategy().checkName(name);
         Items.verifyItemDoesNotAlreadyExist(parent, name, null);
 
         TopLevelItem item = type.newInstance(parent, name);
         item.onCreatedFromScratch();
         item.save();
         add(item);
-        Jenkins.getInstance().rebuildDependencyGraphAsync();
+        Jenkins.get().rebuildDependencyGraphAsync();
 
         if (notify)
             ItemListener.fireOnCreated(item);

--- a/core/src/main/java/hudson/model/ItemVisitor.java
+++ b/core/src/main/java/hudson/model/ItemVisitor.java
@@ -56,6 +56,6 @@ public abstract class ItemVisitor {
      * To walk a subtree, call {@link #onItemGroup(ItemGroup)} or {@link #onItem(Item)}
      */
     public final void walk() {
-        onItemGroup(Jenkins.getInstance());
+        onItemGroup(Jenkins.get());
     }
 }

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -153,7 +153,7 @@ public class Items {
      * Returns all the registered {@link TopLevelItemDescriptor}s.
      */
     public static DescriptorExtensionList<TopLevelItem,TopLevelItemDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(TopLevelItem.class);
+        return Jenkins.get().getDescriptorList(TopLevelItem.class);
     }
 
     /**
@@ -179,7 +179,7 @@ public class Items {
             acl = ((AccessControlled) c).getACL();
         } else {
             // fall back to root
-            acl = Jenkins.getInstance().getACL();
+            acl = Jenkins.get().getACL();
         }
         for (TopLevelItemDescriptor d: all()) {
             if (acl.hasCreatePermission(a, c, d) && d.isApplicableIn(c)) {
@@ -222,7 +222,7 @@ public class Items {
      * Does the opposite of {@link #toNameList(Collection)}.
      */
     public static <T extends Item> List<T> fromNameList(ItemGroup context, @Nonnull String list, @Nonnull Class<T> type) {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         
         List<T> r = new ArrayList<>();
         if (jenkins == null) {
@@ -466,11 +466,11 @@ public class Items {
      */
     public static @CheckForNull <T extends Item> T findNearest(Class<T> type, String name, ItemGroup context) {
         List<String> names = new ArrayList<>();
-        for (T item: Jenkins.getInstance().allItems(type)) {
+        for (T item: Jenkins.get().allItems(type)) {
             names.add(item.getRelativeNameFrom(context));
         }
         String nearest = EditDistance.findNearest(name, names);
-        return Jenkins.getInstance().getItem(nearest, context, type);
+        return Jenkins.get().getItem(nearest, context, type);
     }
 
     /**

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -176,17 +176,17 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
         }
 
         public @Override JDK[] getInstallations() {
-            return Jenkins.getInstance().getJDKs().toArray(new JDK[0]);
+            return Jenkins.get().getJDKs().toArray(new JDK[0]);
         }
 
         public @Override void setInstallations(JDK... jdks) {
-            Jenkins.getInstance().setJDKs(Arrays.asList(jdks));
+            Jenkins.get().setJDKs(Arrays.asList(jdks));
         }
 
         @Override
         public List<? extends ToolInstaller> getDefaultInstallers() {
             try {
-                Class<? extends ToolInstaller> jdkInstallerClass = Jenkins.getInstance().getPluginManager()
+                Class<? extends ToolInstaller> jdkInstallerClass = Jenkins.get().getPluginManager()
                         .uberClassLoader.loadClass("hudson.tools.JDKInstaller").asSubclass(ToolInstaller.class);
                 Constructor<? extends ToolInstaller> constructor = jdkInstallerClass.getConstructor(String.class, boolean.class);
                 return Collections.singletonList(constructor.newInstance(null, false));

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -203,7 +203,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
         File buildDir = getBuildDir();
         runIdMigrator = new RunIdMigrator();
-        runIdMigrator.migrate(buildDir, Jenkins.getInstance().getRootDir());
+        runIdMigrator.migrate(buildDir, Jenkins.get().getRootDir());
 
         TextFile f = getNextBuildNumberFile();
         if (f.exists()) {
@@ -682,7 +682,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     public static class SubItemBuildsLocationImpl extends ItemListener {
         @Override
         public void onLocationChanged(Item item, String oldFullName, String newFullName) {
-            final Jenkins jenkins = Jenkins.getInstance();
+            final Jenkins jenkins = Jenkins.get();
             if (!jenkins.isDefaultBuildDir() && item instanceof Job) {
                 File newBuildDir = ((Job)item).getBuildDir();
                 try {
@@ -1351,7 +1351,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
             ItemListener.fireOnUpdated(this);
 
-            final ProjectNamingStrategy namingStrategy = Jenkins.getInstance().getProjectNamingStrategy();
+            final ProjectNamingStrategy namingStrategy = Jenkins.get().getProjectNamingStrategy();
                 if(namingStrategy.isForceExistingJobs()){
                     namingStrategy.checkName(name);
                 }
@@ -1603,7 +1603,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      */
     @Override
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.get().getAuthorizationStrategy().getACL(this);
     }
 
     public BuildTimelineWidget getTimeline() {

--- a/core/src/main/java/hudson/model/JobParameterDefinition.java
+++ b/core/src/main/java/hudson/model/JobParameterDefinition.java
@@ -56,6 +56,6 @@ public class JobParameterDefinition extends SimpleParameterDefinition {
     }
 
     public ParameterValue createValue(String value) {
-        return new JobParameterValue(getName(), Jenkins.getInstance().getItemByFullName(value,Job.class));
+        return new JobParameterValue(getName(), Jenkins.get().getItemByFullName(value,Job.class));
     }
 }

--- a/core/src/main/java/hudson/model/JobProperty.java
+++ b/core/src/main/java/hudson/model/JobProperty.java
@@ -102,7 +102,7 @@ public abstract class JobProperty<J extends Job<?,?>> implements ReconfigurableD
      */
     @Override
     public JobPropertyDescriptor getDescriptor() {
-        return (JobPropertyDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (JobPropertyDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**

--- a/core/src/main/java/hudson/model/JobPropertyDescriptor.java
+++ b/core/src/main/java/hudson/model/JobPropertyDescriptor.java
@@ -107,6 +107,6 @@ public abstract class JobPropertyDescriptor extends Descriptor<JobProperty<?>> {
     }
 
     public static Collection<JobPropertyDescriptor> all() {
-        return (Collection) Jenkins.getInstance().getDescriptorList(JobProperty.class);
+        return (Collection) Jenkins.get().getDescriptorList(JobProperty.class);
     }
 }

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -110,7 +110,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
 
             @Override
             public int computeQueueLength() {
-                return Jenkins.getInstance().getQueue().countBuildableItemsFor(Label.this);
+                return Jenkins.get().getQueue().countBuildableItemsFor(Label.this);
             }
 
             @Override
@@ -218,7 +218,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         if(nodes!=null) return nodes;
 
         Set<Node> r = new HashSet<>();
-        Jenkins h = Jenkins.getInstance();
+        Jenkins h = Jenkins.get();
         if(this.matches(h))
             r.add(h);
         for (Node n : h.getNodes()) {
@@ -242,7 +242,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     public Set<Cloud> getClouds() {
         if(clouds==null) {
             Set<Cloud> r = new HashSet<>();
-            Jenkins h = Jenkins.getInstance();
+            Jenkins h = Jenkins.get();
             for (Cloud c : h.clouds) {
                 if(c.canProvision(this))
                     r.add(c);
@@ -382,7 +382,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     @Exported
     public List<AbstractProject> getTiedJobs() {
         List<AbstractProject> r = new ArrayList<>();
-        for (AbstractProject<?,?> p : Jenkins.getInstance().allItems(AbstractProject.class)) {
+        for (AbstractProject<?,?> p : Jenkins.get().allItems(AbstractProject.class)) {
             if(p instanceof TopLevelItem && this.equals(p.getAssignedLabel()))
                 r.add(p);
         }
@@ -409,7 +409,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
             int result = 0;
             // top level gives the map without checking security of items in the map
             // therefore best performance
-            for (TopLevelItem topLevelItem : Jenkins.getInstance().getItemMap().values()) {
+            for (TopLevelItem topLevelItem : Jenkins.get().getItemMap().values()) {
                 if (topLevelItem instanceof AbstractProject) {
                     final AbstractProject project = (AbstractProject) topLevelItem;
                     if (matches(project.getAssignedLabelString())) {
@@ -589,7 +589,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         }
 
         public Object unmarshal(HierarchicalStreamReader reader, final UnmarshallingContext context) {
-            return Jenkins.getInstance().getLabel(reader.getValue());
+            return Jenkins.get().getLabel(reader.getValue());
         }
     }
 
@@ -609,7 +609,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         if(labels.length()>0) {
             final QuotedStringTokenizer tokenizer = new QuotedStringTokenizer(labels);
             while (tokenizer.hasMoreTokens())
-                r.add(Jenkins.getInstance().getLabelAtom(tokenizer.nextToken()));
+                r.add(Jenkins.get().getLabelAtom(tokenizer.nextToken()));
             }
         return r;
     }
@@ -618,7 +618,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
      * Obtains a label by its {@linkplain #getName() name}.
      */
     public static Label get(String l) {
-        return Jenkins.getInstance().getLabel(l);
+        return Jenkins.get().getLabel(l);
     }
 
     /**

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -426,7 +426,7 @@ public class ListView extends View implements DirectlyModifiableView {
         TopLevelItem item = getOwner().getItemGroup().getItem(name);
         if (item == null) {
             name = Items.getCanonicalName(getOwner().getItemGroup(), name);
-            item = Jenkins.getInstance().getItemByFullName(name, TopLevelItem.class);
+            item = Jenkins.get().getItemByFullName(name, TopLevelItem.class);
         }
         return item;
     }
@@ -523,7 +523,7 @@ public class ListView extends View implements DirectlyModifiableView {
             }
         }
         private void locationChanged(String oldFullName, String newFullName) {
-            final Jenkins jenkins = Jenkins.getInstance();
+            final Jenkins jenkins = Jenkins.get();
             locationChanged(jenkins, oldFullName, newFullName);
             for (Item g : jenkins.allItems()) {
                 if (g instanceof ViewGroup) {
@@ -568,7 +568,7 @@ public class ListView extends View implements DirectlyModifiableView {
             }
         }
         private void deleted(Item item) {
-            final Jenkins jenkins = Jenkins.getInstance();
+            final Jenkins jenkins = Jenkins.get();
             deleted(jenkins, item);
             for (Item g : jenkins.allItems()) {
                 if (g instanceof ViewGroup) {

--- a/core/src/main/java/hudson/model/LoadStatistics.java
+++ b/core/src/main/java/hudson/model/LoadStatistics.java
@@ -332,7 +332,7 @@ public abstract class LoadStatistics {
      */
     public LoadStatisticsSnapshot computeSnapshot() {
         if (modern) {
-            return computeSnapshot(Jenkins.getInstance().getQueue().getBuildableItems());
+            return computeSnapshot(Jenkins.get().getQueue().getBuildableItems());
         } else {
             int t = computeTotalExecutors();
             int i = computeIdleExecutors();
@@ -389,7 +389,7 @@ public abstract class LoadStatistics {
         }
 
         protected void doRun() {
-            Jenkins j = Jenkins.getInstance();
+            Jenkins j = Jenkins.get();
             List<Queue.BuildableItem> bis = j.getQueue().getBuildableItems();
 
             // update statistics on agents

--- a/core/src/main/java/hudson/model/ManageJenkinsAction.java
+++ b/core/src/main/java/hudson/model/ManageJenkinsAction.java
@@ -35,7 +35,7 @@ import org.jenkinsci.Symbol;
 @Extension(ordinal=100) @Symbol("manageJenkins")
 public class ManageJenkinsAction implements RootAction {
     public String getIconFileName() {
-        if (Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
+        if (Jenkins.get().hasPermission(Jenkins.ADMINISTER))
             return "gear2.png";
         else
             return null;

--- a/core/src/main/java/hudson/model/MyView.java
+++ b/core/src/main/java/hudson/model/MyView.java
@@ -102,7 +102,7 @@ public class MyView extends View {
          */
         @Override
         public boolean isInstantiable() {
-            return Jenkins.getInstance().isUseSecurity();
+            return Jenkins.get().isUseSecurity();
         }
 
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -237,11 +237,11 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
     }
 
     public ViewsTabBar getViewsTabBar() {
-        return Jenkins.getInstance().getViewsTabBar();
+        return Jenkins.get().getViewsTabBar();
     }
 
     public List<Action> getViewActions() {
-        // Jenkins.getInstance().getViewActions() are tempting but they are in a wrong scope
+        // Jenkins.get().getViewActions() are tempting but they are in a wrong scope
         return Collections.emptyList();
     }
 
@@ -250,7 +250,7 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
     }
 
     public MyViewsTabBar getMyViewsTabBar() {
-        return Jenkins.getInstance().getMyViewsTabBar();
+        return Jenkins.get().getMyViewsTabBar();
     }
     
     @Extension @Symbol("myView")

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -129,7 +129,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
     @Override
     public void save() throws IOException {
         // this should be a no-op unless this node instance is the node instance in Jenkins' list of nodes
-        // thus where Jenkins.getInstance() == null there is no list of nodes, so we do a no-op
+        // thus where Jenkins.get() == null there is no list of nodes, so we do a no-op
         // Nodes.updateNode(n) will only persist the node record if the node instance is in the list of nodes
         // so either path results in the same behaviour: the node instance is only saved if it is in the list of nodes
         // for all other cases we do not know where to persist the node record and hence we follow the default
@@ -203,7 +203,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
      */
     @CheckForNull
     public final Computer toComputer() {
-        AbstractCIBase ciBase = Jenkins.getInstance();
+        AbstractCIBase ciBase = Jenkins.get();
         return ciBase.getComputer(this);
     }
 
@@ -390,8 +390,8 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
             // flyweight tasks need to get executed somewhere, if every node
             if (!(item.task instanceof Queue.FlyweightTask && (
                     this instanceof Jenkins
-                            || Jenkins.getInstance().getNumExecutors() < 1
-                            || Jenkins.getInstance().getMode() == Mode.EXCLUSIVE)
+                            || Jenkins.get().getNumExecutors() < 1
+                            || Jenkins.get().getMode() == Mode.EXCLUSIVE)
             )) {
                 return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsReserved(getDisplayName()));   // this node is reserved for tasks that are tied to it
             }
@@ -510,7 +510,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
     }
 
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.get().getAuthorizationStrategy().getACL(this);
     }
 
     public Node reconfigure(final StaplerRequest req, JSONObject form) throws FormException {

--- a/core/src/main/java/hudson/model/OverallLoadStatistics.java
+++ b/core/src/main/java/hudson/model/OverallLoadStatistics.java
@@ -67,7 +67,7 @@ public class OverallLoadStatistics extends LoadStatistics {
 
     @Override
     public int computeQueueLength() {
-        return Jenkins.getInstance().getQueue().countBuildableItems();
+        return Jenkins.get().getQueue().countBuildableItems();
     }
 
     @Override

--- a/core/src/main/java/hudson/model/PageDecorator.java
+++ b/core/src/main/java/hudson/model/PageDecorator.java
@@ -114,6 +114,6 @@ public abstract class PageDecorator extends Descriptor<PageDecorator> implements
      * Returns all the registered {@link PageDecorator} descriptors.
      */
     public static ExtensionList<PageDecorator> all() {
-        return Jenkins.getInstance().getDescriptorList(PageDecorator.class);
+        return Jenkins.get().getDescriptorList(PageDecorator.class);
     }
 }

--- a/core/src/main/java/hudson/model/ParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ParameterDefinition.java
@@ -144,7 +144,7 @@ public abstract class ParameterDefinition implements
      */
     public String getFormattedDescription() {
         try {
-            return Jenkins.getInstance().getMarkupFormatter().translate(description);
+            return Jenkins.get().getMarkupFormatter().translate(description);
         } catch (IOException e) {
             LOGGER.warning("failed to translate description using configured markup formatter");
             return "";
@@ -156,7 +156,7 @@ public abstract class ParameterDefinition implements
      */
     @Override
     public ParameterDescriptor getDescriptor() {
-        return (ParameterDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (ParameterDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -223,7 +223,7 @@ public abstract class ParameterDefinition implements
      * Returns all the registered {@link ParameterDefinition} descriptors.
      */
     public static DescriptorExtensionList<ParameterDefinition,ParameterDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(ParameterDefinition.class);
+        return Jenkins.get().getDescriptorList(ParameterDefinition.class);
     }
 
     /**

--- a/core/src/main/java/hudson/model/ParameterValue.java
+++ b/core/src/main/java/hudson/model/ParameterValue.java
@@ -105,7 +105,7 @@ public abstract class ParameterValue implements Serializable {
     @Restricted(DoNotUse.class) // for value.jelly
     public String getFormattedDescription() {
         try {
-            return Jenkins.getInstance().getMarkupFormatter().translate(description);
+            return Jenkins.get().getMarkupFormatter().translate(description);
         } catch (IOException e) {
             LOGGER.warning("failed to translate description using configured markup formatter");
             return "";

--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -158,7 +158,7 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
             }
         }
 
-    	WaitingItem item = Jenkins.getInstance().getQueue().schedule(
+    	WaitingItem item = Jenkins.get().getQueue().schedule(
                 getJob(), delay.getTimeInSeconds(), new ParametersAction(values), new CauseAction(new Cause.UserIdCause()));
         if (item!=null) {
             String url = formData.optString("redirectTo");
@@ -187,7 +187,7 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
         if (delay==null)
             delay=new TimeDuration(TimeUnit.MILLISECONDS.convert(getJob().getQuietPeriod(), TimeUnit.SECONDS));
 
-        Queue.Item item = Jenkins.getInstance().getQueue().schedule2(
+        Queue.Item item = Jenkins.get().getQueue().schedule2(
                 getJob(), delay.getTimeInSeconds(), new ParametersAction(values), ParameterizedJobMixIn.getBuildCause(getJob(), req)).getItem();
 
         if (item != null) {

--- a/core/src/main/java/hudson/model/ProxyView.java
+++ b/core/src/main/java/hudson/model/ProxyView.java
@@ -57,7 +57,7 @@ public class ProxyView extends View implements StaplerFallback {
     public ProxyView(String name) {
         super(name);
 
-        if (Jenkins.getInstance().getView(name) != null) {
+        if (Jenkins.get().getView(name) != null) {
             // if this is a valid global view name, let's assume the
             // user wants to show it
             proxiedViewName = name;
@@ -67,9 +67,9 @@ public class ProxyView extends View implements StaplerFallback {
     public View getProxiedView() {
         if (proxiedViewName == null) {
             // just so we avoid errors just after creation
-            return Jenkins.getInstance().getPrimaryView();
+            return Jenkins.get().getPrimaryView();
         } else {
-            return Jenkins.getInstance().getView(proxiedViewName);
+            return Jenkins.get().getView(proxiedViewName);
         }
     }
 
@@ -99,7 +99,7 @@ public class ProxyView extends View implements StaplerFallback {
     @Override
     protected void submit(StaplerRequest req) throws IOException, ServletException, FormException {
         String proxiedViewName = req.getSubmittedForm().getString("proxiedViewName");
-        if (Jenkins.getInstance().getView(proxiedViewName) == null) {
+        if (Jenkins.get().getView(proxiedViewName) == null) {
             throw new FormException("Not an existing global view", "proxiedViewName");
         }
         this.proxiedViewName = proxiedViewName;
@@ -120,7 +120,7 @@ public class ProxyView extends View implements StaplerFallback {
         String view = Util.fixEmpty(value);
         if(view==null) return FormValidation.ok();
 
-        if(Jenkins.getInstance().getView(view)!=null)
+        if(Jenkins.get().getView(view)!=null)
             return FormValidation.ok();
         else
             return FormValidation.error(Messages.ProxyView_NoSuchViewExists(value));

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -386,7 +386,7 @@ public class Queue extends ResourceController implements Saveable {
                 try (BufferedReader in = Files.newBufferedReader(Util.fileToPath(queueFile), Charset.defaultCharset())) {
                     String line;
                     while ((line = in.readLine()) != null) {
-                        AbstractProject j = Jenkins.getInstance().getItemByFullName(line, AbstractProject.class);
+                        AbstractProject j = Jenkins.get().getItemByFullName(line, AbstractProject.class);
                         if (j != null)
                             j.scheduleBuild();
                     }
@@ -493,7 +493,7 @@ public class Queue extends ResourceController implements Saveable {
      * Wipes out all the items currently in the queue, as if all of them are cancelled at once.
      */
     public void clear() {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         lock.lock();
         try { try {
             for (WaitingItem i : new ArrayList<>(
@@ -1707,7 +1707,7 @@ public class Queue extends ResourceController implements Saveable {
     private Runnable makeFlyWeightTaskBuildable(final BuildableItem p){
         //we double check if this is a flyweight task
         if (p.task instanceof FlyweightTask) {
-            Jenkins h = Jenkins.getInstance();
+            Jenkins h = Jenkins.get();
 
             Label lbl = p.getAssignedLabel();
 
@@ -1788,7 +1788,7 @@ public class Queue extends ResourceController implements Saveable {
      * @since 1.598
      */
     public static boolean isBlockedByShutdown(Task task) {
-        return Jenkins.getInstance().isQuietingDown() && !(task instanceof NonBlockingTask);
+        return Jenkins.get().isQuietingDown() && !(task instanceof NonBlockingTask);
     }
 
     public Api getApi() {
@@ -2287,7 +2287,7 @@ public class Queue extends ResourceController implements Saveable {
         @RequirePOST
         public HttpResponse doCancelQueue() throws IOException, ServletException {
             if(hasCancelPermission()){
-                Jenkins.getInstance().getQueue().cancel(this);
+                Jenkins.get().getQueue().cancel(this);
             }
             return HttpResponses.forwardToPreviousPage();
         }
@@ -2636,7 +2636,7 @@ public class Queue extends ResourceController implements Saveable {
         }
 
         public CauseOfBlockage getCauseOfBlockage() {
-            Jenkins jenkins = Jenkins.getInstance();
+            Jenkins jenkins = Jenkins.get();
             if(isBlockedByShutdown(task))
                 return CauseOfBlockage.fromMessage(Messages._Queue_HudsonIsAboutToShutDown());
 
@@ -2805,7 +2805,7 @@ public class Queue extends ResourceController implements Saveable {
 
 			@Override
 			public Object fromString(String string) {
-                Object item = Jenkins.getInstance().getItemByFullName(string);
+                Object item = Jenkins.get().getItemByFullName(string);
                 if(item==null)  throw new NoSuchElementException("No such job exists: "+string);
                 return item;
 			}
@@ -2828,7 +2828,7 @@ public class Queue extends ResourceController implements Saveable {
 				String[] split = string.split("#");
 				String projectName = split[0];
 				int buildNumber = Integer.parseInt(split[1]);
-				Job<?,?> job = (Job<?,?>) Jenkins.getInstance().getItemByFullName(projectName);
+				Job<?,?> job = (Job<?,?>) Jenkins.get().getItemByFullName(projectName);
                 if(job==null)  throw new NoSuchElementException("No such job exists: "+projectName);
 				Run<?,?> run = job.getBuildByNumber(buildNumber);
                 if(run==null)  throw new NoSuchElementException("No such build: "+string);
@@ -2853,7 +2853,7 @@ public class Queue extends ResourceController implements Saveable {
 
 			@Override
 			public Object fromString(String string) {
-                return Jenkins.getInstance().getQueue();
+                return Jenkins.get().getQueue();
 			}
 
 			@Override
@@ -3036,7 +3036,7 @@ public class Queue extends ResourceController implements Saveable {
 
     @CLIResolver
     public static Queue getInstance() {
-        return Jenkins.getInstance().getQueue();
+        return Jenkins.get().getQueue();
     }
 
     /**

--- a/core/src/main/java/hudson/model/RSS.java
+++ b/core/src/main/java/hudson/model/RSS.java
@@ -77,12 +77,12 @@ public final class RSS {
         req.setAttribute("title",title);
         req.setAttribute("url",url);
         req.setAttribute("entries",entries);
-        req.setAttribute("rootURL", Jenkins.getInstance().getRootUrl());
+        req.setAttribute("rootURL", Jenkins.get().getRootUrl());
 
         String flavor = req.getParameter("flavor");
         if(flavor==null)    flavor="atom";
         flavor = flavor.replace('/', '_'); // Don't allow path to any jelly
 
-        req.getView(Jenkins.getInstance(),"/hudson/"+flavor+".jelly").forward(req,rsp);
+        req.getView(Jenkins.get(),"/hudson/"+flavor+".jelly").forward(req,rsp);
     }
 }

--- a/core/src/main/java/hudson/model/RestartListener.java
+++ b/core/src/main/java/hudson/model/RestartListener.java
@@ -53,7 +53,7 @@ public abstract class RestartListener implements ExtensionPoint {
     public static class Default extends RestartListener {
         @Override
         public boolean isReadyToRestart() throws IOException, InterruptedException {
-            for (Computer c : Jenkins.getInstance().getComputers()) {
+            for (Computer c : Jenkins.get().getComputers()) {
                 if (c.isOnline()) {
                     for (Executor e : c.getAllExecutors()) {
                         if (blocksRestart(e)) {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -542,7 +542,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * @since 1.433 
      */
     public @CheckForNull Executor getOneOffExecutor() {
-        for( Computer c : Jenkins.getInstance().getComputers() ) {
+        for( Computer c : Jenkins.get().getComputers() ) {
             for (Executor e : c.getOneOffExecutors()) {
                 if(e.getCurrentExecutable()==this)
                     return e;

--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -105,7 +105,7 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
     }
 
     public Job getProject() {
-        return Jenkins.getInstance().getItemByFullName(projectName, Job.class);
+        return Jenkins.get().getItemByFullName(projectName, Job.class);
     }
 
     /**
@@ -154,7 +154,7 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
         }
         
         public AutoCompletionCandidates doAutoCompleteProjectName(@QueryParameter String value) {
-            return AutoCompletionCandidates.ofJobNames(Job.class, value, null, Jenkins.getInstance());
+            return AutoCompletionCandidates.ofJobNames(Job.class, value, null, Jenkins.get());
         }
 
     }

--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -100,7 +100,7 @@ public class RunParameterValue extends ParameterValue {
     public void buildEnvironment(Run<?,?> build, EnvVars env) {
         Run run = getRun();
         
-        String value = (null == run) ? "UNKNOWN" : Jenkins.getInstance().getRootUrl() + run.getUrl();
+        String value = (null == run) ? "UNKNOWN" : Jenkins.get().getRootUrl() + run.getUrl();
         env.put(name, value);
 
         env.put(name + ".jobName", getJobName());   // undocumented, left for backward compatibility

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -197,7 +197,7 @@ public abstract class Slave extends Node implements Serializable {
         getAssignedLabels();    // compute labels now
 
         this.nodeProperties.replaceBy(nodeProperties);
-         Slave node = (Slave) Jenkins.getInstance().getNode(name);
+         Slave node = (Slave) Jenkins.get().getNode(name);
 
        if(node!=null){
             this.userId= node.getUserId(); //agent has already existed
@@ -232,7 +232,7 @@ public abstract class Slave extends Node implements Serializable {
     public ComputerLauncher getLauncher() {
         if (launcher == null && !StringUtils.isEmpty(agentCommand)) {
             try {
-                launcher = (ComputerLauncher) Jenkins.getInstance().getPluginManager().uberClassLoader.loadClass("hudson.slaves.CommandLauncher").getConstructor(String.class, EnvVars.class).newInstance(agentCommand, null);
+                launcher = (ComputerLauncher) Jenkins.get().getPluginManager().uberClassLoader.loadClass("hudson.slaves.CommandLauncher").getConstructor(String.class, EnvVars.class).newInstance(agentCommand, null);
                 agentCommand = null;
                 save();
             } catch (Exception x) {
@@ -425,7 +425,7 @@ public abstract class Slave extends Node implements Serializable {
                 }
             }
             
-            URL res = Jenkins.getInstance().servletContext.getResource("/WEB-INF/" + name);
+            URL res = Jenkins.get().servletContext.getResource("/WEB-INF/" + name);
             if(res==null) {
                 throw new FileNotFoundException(name); // giving up
             } else {
@@ -565,7 +565,7 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     public SlaveDescriptor getDescriptor() {
-        Descriptor d = Jenkins.getInstance().getDescriptorOrDie(getClass());
+        Descriptor d = Jenkins.get().getDescriptorOrDie(getClass());
         if (d instanceof SlaveDescriptor)
             return (SlaveDescriptor) d;
         throw new IllegalStateException(d.getClass()+" needs to extend from SlaveDescriptor");
@@ -604,7 +604,7 @@ public abstract class Slave extends Node implements Serializable {
         @Restricted(NoExternalUse.class) // intended for use by Jelly EL only (plus hack in DelegatingComputerLauncher)
         public final List<Descriptor<ComputerLauncher>> computerLauncherDescriptors(@CheckForNull Slave it) {
             DescriptorExtensionList<ComputerLauncher, Descriptor<ComputerLauncher>> all =
-                    Jenkins.getInstance().getDescriptorList(
+                    Jenkins.get().getDescriptorList(
                             ComputerLauncher.class);
             return it == null ? DescriptorVisibilityFilter.applyType(clazz, all)
                     : DescriptorVisibilityFilter.apply(it, all);
@@ -638,7 +638,7 @@ public abstract class Slave extends Node implements Serializable {
         public final List<NodePropertyDescriptor> nodePropertyDescriptors(@CheckForNull Slave it) {
             List<NodePropertyDescriptor> result = new ArrayList<>();
             Collection<NodePropertyDescriptor> list =
-                    (Collection) Jenkins.getInstance().getDescriptorList(NodeProperty.class);
+                    (Collection) Jenkins.get().getDescriptorList(NodeProperty.class);
             for (NodePropertyDescriptor npd : it == null
                     ? DescriptorVisibilityFilter.applyType(clazz, list)
                     : DescriptorVisibilityFilter.apply(it, list)) {

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -267,7 +267,7 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
      */
     @Deprecated
     public TopLevelItem newInstance(String name) {
-        return newInstance(Jenkins.getInstance(), name);
+        return newInstance(Jenkins.get(), name);
     }
 
     /**

--- a/core/src/main/java/hudson/model/TreeView.java
+++ b/core/src/main/java/hudson/model/TreeView.java
@@ -93,7 +93,7 @@ public class TreeView extends View implements ViewGroup {
      * concurrent modification issue.
      */
     public synchronized List<TopLevelItem> getItems() {
-        return Jenkins.getInstance().getItems();
+        return Jenkins.get().getItems();
 //        List<TopLevelItem> items = new ArrayList<TopLevelItem>(jobNames.size());
 //        for (String name : jobNames) {
 //            TopLevelItem item = Hudson.getInstance().getItem(name);
@@ -184,7 +184,7 @@ public class TreeView extends View implements ViewGroup {
     }
 
     public ViewsTabBar getViewsTabBar() {
-        return Jenkins.getInstance().getViewsTabBar();
+        return Jenkins.get().getViewsTabBar();
     }
 
     public ItemGroup<? extends TopLevelItem> getItemGroup() {

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -487,7 +487,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         try {
             String correlationId = request.getParameter("correlationId");
             Map<String,Object> response = new HashMap<>();
-            response.put("state", Jenkins.getInstance().getInstallState().name());
+            response.put("state", Jenkins.get().getInstallState().name());
             List<Map<String, String>> installStates = new ArrayList<>();
             response.put("jobs", installStates);
             List<UpdateCenterJob> jobCopy = getJobs();
@@ -912,7 +912,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     }
 
     private XmlFile getConfigFile() {
-        return new XmlFile(XSTREAM,new File(Jenkins.getInstance().root,
+        return new XmlFile(XSTREAM,new File(Jenkins.get().root,
                                     UpdateCenter.class.getName()+".xml"));
     }
 
@@ -1029,7 +1029,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         }
 
         public Data getData() {
-            UpdateSite cs = Jenkins.getInstance().getUpdateCenter().getCoreSource();
+            UpdateSite cs = Jenkins.get().getUpdateCenter().getCoreSource();
             if (cs!=null)   return cs.getData();
             return null;
         }
@@ -1439,7 +1439,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             try {
                 // safeRestart records the current authentication for the log, so set it to the managing user
                 try (ACLContext acl = ACL.as(User.get(authentication, false, Collections.emptyMap()))) {
-                    Jenkins.getInstance().safeRestart();
+                    Jenkins.get().safeRestart();
                 }
             } catch (RestartNotSupportedException exception) {
                 // ignore if restart is not allowed
@@ -1964,7 +1964,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         @Exported
         public final Plugin plugin;
 
-        protected final PluginManager pm = Jenkins.getInstance().getPluginManager();
+        protected final PluginManager pm = Jenkins.get().getPluginManager();
 
         /**
          * True to load the plugin into this Jenkins, false to wait until restart.
@@ -2134,7 +2134,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
          */
         public final Plugin plugin;
 
-        private final PluginManager pm = Jenkins.getInstance().getPluginManager();
+        private final PluginManager pm = Jenkins.get().getPluginManager();
 
         public PluginDowngradeJob(Plugin plugin, UpdateSite site, Authentication auth) {
             super(site, auth);
@@ -2352,7 +2352,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
 
     @Restricted(NoExternalUse.class)
     public static void updateDefaultSite() {
-        final UpdateSite site = Jenkins.getInstance().getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT);
+        final UpdateSite site = Jenkins.get().getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT);
         if (site == null) {
             LOGGER.log(Level.SEVERE, "Upgrading Jenkins. Cannot retrieve the default Update Site ''{0}''. "
                     + "Plugin installation may fail.", UpdateCenter.ID_DEFAULT);
@@ -2372,7 +2372,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         }
         return this;
     }

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -174,7 +174,7 @@ public class UpdateSite {
      */
     public @CheckForNull Future<FormValidation> updateDirectly(final boolean signatureCheck) {
         if (! getDataFile().exists() || isDue()) {
-            return Jenkins.getInstance().getUpdateCenter().updateService.submit(new Callable<FormValidation>() {
+            return Jenkins.get().getUpdateCenter().updateService.submit(new Callable<FormValidation>() {
                 @Override public FormValidation call() throws Exception {
                     return updateDirectlyNow(signatureCheck);
                 }
@@ -307,7 +307,7 @@ public class UpdateSite {
      */
     @RequirePOST
     public HttpResponse doInvalidateData() {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         dataTimestamp = 0;
         data = null;
         return HttpResponses.ok();
@@ -397,7 +397,7 @@ public class UpdateSite {
      * This is where we store the update center data.
      */
     private TextFile getDataFile() {
-        return new TextFile(new File(Jenkins.getInstance().getRootDir(),
+        return new TextFile(new File(Jenkins.get().getRootDir(),
                                      "updates/" + getId()+".json"));
     }
     
@@ -413,7 +413,7 @@ public class UpdateSite {
         if(data==null)      return Collections.emptyList(); // fail to determine
         
         List<Plugin> r = new ArrayList<>();
-        for (PluginWrapper pw : Jenkins.getInstance().getPluginManager().getPlugins()) {
+        for (PluginWrapper pw : Jenkins.get().getPluginManager().getPlugins()) {
             Plugin p = pw.getUpdateInfo();
             if(p!=null) r.add(p);
         }
@@ -429,7 +429,7 @@ public class UpdateSite {
         Data data = getData();
         if(data==null)      return false;
         
-        for (PluginWrapper pw : Jenkins.getInstance().getPluginManager().getPlugins()) {
+        for (PluginWrapper pw : Jenkins.get().getPluginManager().getPlugins()) {
             if(!pw.isBundled() && pw.getUpdateInfo()!=null)
                 // do not advertize updates to bundled plugins, since we generally want users to get them
                 // as a part of jenkins.war updates. This also avoids unnecessary pinning of plugins. 
@@ -894,7 +894,7 @@ public class UpdateSite {
                 case PLUGIN:
 
                     // check whether plugin is installed
-                    PluginWrapper plugin = Jenkins.getInstance().getPluginManager().getPlugin(this.component);
+                    PluginWrapper plugin = Jenkins.get().getPluginManager().getPlugin(this.component);
                     if (plugin == null) {
                         return false;
                     }
@@ -1040,7 +1040,7 @@ public class UpdateSite {
          */
         @Exported
         public PluginWrapper getInstalled() {
-            PluginManager pm = Jenkins.getInstance().getPluginManager();
+            PluginManager pm = Jenkins.get().getPluginManager();
             return pm.getPlugin(name);
         }
 
@@ -1092,7 +1092,7 @@ public class UpdateSite {
 
             for(Map.Entry<String,String> e : dependencies.entrySet()) {
                 VersionNumber requiredVersion = e.getValue() != null ? new VersionNumber(e.getValue()) : null;
-                Plugin depPlugin = Jenkins.getInstance().getUpdateCenter().getPlugin(e.getKey(), requiredVersion);
+                Plugin depPlugin = Jenkins.get().getUpdateCenter().getPlugin(e.getKey(), requiredVersion);
                 if (depPlugin == null) {
                     LOGGER.log(warnedMissing.add(e.getKey()) ? Level.WARNING : Level.FINE, "Could not find dependency {0} of {1}", new Object[] {e.getKey(), name});
                     continue;
@@ -1117,7 +1117,7 @@ public class UpdateSite {
 
             for(Map.Entry<String,String> e : optionalDependencies.entrySet()) {
                 VersionNumber requiredVersion = e.getValue() != null ? new VersionNumber(e.getValue()) : null;
-                Plugin depPlugin = Jenkins.getInstance().getUpdateCenter().getPlugin(e.getKey(), requiredVersion);
+                Plugin depPlugin = Jenkins.get().getUpdateCenter().getPlugin(e.getKey(), requiredVersion);
                 if (depPlugin == null) {
                     continue;
                 }
@@ -1337,8 +1337,8 @@ public class UpdateSite {
          */
         @Restricted(NoExternalUse.class)
         public Future<UpdateCenterJob> deploy(boolean dynamicLoad, @CheckForNull UUID correlationId) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-            UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            UpdateCenter uc = Jenkins.get().getUpdateCenter();
             for (Plugin dep : getNeededDependencies()) {
                 UpdateCenter.InstallationJob job = uc.getJob(dep);
                 if (job == null || job.status instanceof UpdateCenter.DownloadJob.Failure) {
@@ -1369,8 +1369,8 @@ public class UpdateSite {
          * Schedules the downgrade of this plugin.
          */
         public Future<UpdateCenterJob> deployBackup() {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-            UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            UpdateCenter uc = Jenkins.get().getUpdateCenter();
             return uc.addJob(uc.new PluginDowngradeJob(this, UpdateSite.this, Jenkins.getAuthentication()));
         }
         /**

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -96,7 +96,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
      */
     public boolean isDue() {
         // user opted out. no data collection.
-        if(!Jenkins.getInstance().isUsageStatisticsCollected() || DISABLED)     return false;
+        if(!Jenkins.get().isUsageStatisticsCollected() || DISABLED)     return false;
         
         long now = System.currentTimeMillis();
         if(now - lastAttempt > DAY) {
@@ -122,7 +122,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
      * Gets the encrypted usage stat data to be sent to the Hudson server.
      */
     public String getStatData() throws IOException {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
 
         JSONObject o = new JSONObject();
         o.put("stat",1);
@@ -196,7 +196,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
         try {
             // for backward compatibility reasons, this configuration is stored in Jenkins
-            Jenkins.getInstance().setNoUsageStatistics(json.has("usageStatisticsCollected") ? null : true);
+            Jenkins.get().setNoUsageStatistics(json.has("usageStatisticsCollected") ? null : true);
             return true;
         } catch (IOException e) {
             throw new FormException(e,"usageStatisticsCollected");

--- a/core/src/main/java/hudson/model/UserProperty.java
+++ b/core/src/main/java/hudson/model/UserProperty.java
@@ -64,14 +64,14 @@ public abstract class UserProperty implements ReconfigurableDescribable<UserProp
 
     // descriptor must be of the UserPropertyDescriptor type
     public UserPropertyDescriptor getDescriptor() {
-        return (UserPropertyDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (UserPropertyDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
      * Returns all the registered {@link UserPropertyDescriptor}s.
      */
     public static DescriptorExtensionList<UserProperty,UserPropertyDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(UserProperty.class);
+        return Jenkins.get().getDescriptorList(UserProperty.class);
     }
 
     public UserProperty reconfigure(StaplerRequest req, JSONObject form) throws FormException {

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -344,7 +344,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     public ViewDescriptor getDescriptor() {
-        return (ViewDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (ViewDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     public String getDisplayName() {
@@ -396,7 +396,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * For now, this just returns the widgets registered to Hudson.
      */
     public List<Widget> getWidgets() {
-        return Collections.unmodifiableList(Jenkins.getInstance().getWidgets());
+        return Collections.unmodifiableList(Jenkins.get().getWidgets());
     }
 
     /**
@@ -422,7 +422,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
     
     public List<Computer> getComputers() {
-        Computer[] computers = Jenkins.getInstance().getComputers();
+        Computer[] computers = Jenkins.get().getComputers();
 
         if (!isFilterExecutors()) {
             return Arrays.asList(computers);
@@ -501,7 +501,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     public List<Queue.Item> getQueueItems() {
-        return filterQueue(Arrays.asList(Jenkins.getInstance().getQueue().getItems()));
+        return filterQueue(Arrays.asList(Jenkins.get().getQueue().getItems()));
     }
 
     /**
@@ -510,7 +510,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      */
     @Deprecated
     public List<Queue.Item> getApproximateQueueItemsQuickly() {
-        return filterQueue(Jenkins.getInstance().getQueue().getApproximateItemsQuickly());
+        return filterQueue(Jenkins.get().getQueue().getApproximateItemsQuickly());
     }
 
     /**
@@ -578,7 +578,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      */
     @Exported(visibility=2,name="url")
     public String getAbsoluteUrl() {
-        return Jenkins.getInstance().getRootUrl()+getUrl();
+        return Jenkins.get().getRootUrl()+getUrl();
     }
 
     public Api getApi() {
@@ -599,7 +599,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * Returns the {@link ACL} for this object.
      */
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.get().getAuthorizationStrategy().getACL(this);
     }
 
     /** @deprecated Does not work properly with moved jobs. Use {@link ItemListener#onLocationChanged} instead. */
@@ -1047,7 +1047,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         try {
             Jenkins.checkGoodName(value);
             value = value.trim(); // why trim *after* checkGoodName? not sure, but ItemGroupMixIn.createTopLevelItem does the same
-            Jenkins.getInstance().getProjectNamingStrategy().checkName(value);
+            Jenkins.get().getProjectNamingStrategy().checkName(value);
         } catch (Failure e) {
             return FormValidation.error(e.getMessage());
         }
@@ -1246,7 +1246,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * Returns all the registered {@link ViewDescriptor}s.
      */
     public static DescriptorExtensionList<View,ViewDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(View.class);
+        return Jenkins.get().getDescriptorList(View.class);
     }
 
     /**

--- a/core/src/main/java/hudson/model/ViewDescriptor.java
+++ b/core/src/main/java/hudson/model/ViewDescriptor.java
@@ -91,7 +91,7 @@ public abstract class ViewDescriptor extends Descriptor<View> {
             DirectlyModifiableTopLevelItemGroup modifiableContainer = (DirectlyModifiableTopLevelItemGroup) container;
             Iterator<String> it = candidates.getValues().iterator();
             while (it.hasNext()) {
-                TopLevelItem item = Jenkins.getInstance().getItem(it.next(), container, TopLevelItem.class);
+                TopLevelItem item = Jenkins.get().getItem(it.next(), container, TopLevelItem.class);
                 if (item == null) {
                     continue; // ?
                 }

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -141,7 +141,7 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
      * @since 1.417
      */
     default ItemGroup<? extends TopLevelItem> getItemGroup() {
-        return Jenkins.getInstance();
+        return Jenkins.get();
     }
 
     /**
@@ -157,7 +157,7 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
      * @since 1.417
      */
     default List<Action> getViewActions() {
-        return Jenkins.getInstance().getActions();
+        return Jenkins.get().getActions();
     }
     
 }

--- a/core/src/main/java/hudson/model/ViewJob.java
+++ b/core/src/main/java/hudson/model/ViewJob.java
@@ -198,7 +198,7 @@ public abstract class ViewJob<JobT extends ViewJob<JobT,RunT>, RunT extends Run<
         }
 
         private boolean terminating() {
-            return Jenkins.getInstance().isTerminating();
+            return Jenkins.get().isTerminating();
         }
 
         @Override

--- a/core/src/main/java/hudson/model/ViewProperty.java
+++ b/core/src/main/java/hudson/model/ViewProperty.java
@@ -59,11 +59,11 @@ public class ViewProperty implements ReconfigurableDescribable<ViewProperty>, Ex
     }
 
     public ViewPropertyDescriptor getDescriptor() {
-        return (ViewPropertyDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (ViewPropertyDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     public static DescriptorExtensionList<ViewProperty,ViewPropertyDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(ViewProperty.class);
+        return Jenkins.get().getDescriptorList(ViewProperty.class);
     }
 
     public ViewProperty reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {

--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -66,7 +66,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
             return;
         }
         List<Node> nodes = new ArrayList<>();
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         nodes.add(j);
         nodes.addAll(j.getNodes());
         for (TopLevelItem item : j.allItems(TopLevelItem.class)) {

--- a/core/src/main/java/hudson/model/labels/LabelAtom.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtom.java
@@ -162,7 +162,7 @@ public class LabelAtom extends Label implements Saveable {
     }
 
     /*package*/ XmlFile getConfigFile() {
-        return new XmlFile(XSTREAM, new File(Jenkins.getInstance().root, "labels/"+name+".xml"));
+        return new XmlFile(XSTREAM, new File(Jenkins.get().root, "labels/"+name+".xml"));
     }
 
     public void save() throws IOException {
@@ -201,7 +201,7 @@ public class LabelAtom extends Label implements Saveable {
      */
     @RequirePOST
     public void doConfigSubmit( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException, FormException {
-        final Jenkins app = Jenkins.getInstance();
+        final Jenkins app = Jenkins.get();
 
         app.checkPermission(Jenkins.ADMINISTER);
 
@@ -221,7 +221,7 @@ public class LabelAtom extends Label implements Saveable {
     @RequirePOST
     @Restricted(DoNotUse.class)
     public synchronized void doSubmitDescription( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         setDescription(req.getParameter("description"));
         rsp.sendRedirect(".");  // go to the top page
@@ -232,12 +232,12 @@ public class LabelAtom extends Label implements Saveable {
      * @see Jenkins#getLabelAtom
      */
     public static @Nullable LabelAtom get(@CheckForNull String l) {
-        return Jenkins.getInstance().getLabelAtom(l);
+        return Jenkins.get().getLabelAtom(l);
     }
 
     public static LabelAtom findNearest(String name) {
         List<String> candidates = new ArrayList<>();
-        for (LabelAtom a : Jenkins.getInstance().getLabelAtoms()) {
+        for (LabelAtom a : Jenkins.get().getLabelAtoms()) {
             candidates.add(a.getName());
         }
         return get(EditDistance.findNearest(name, candidates));

--- a/core/src/main/java/hudson/model/labels/LabelAtomProperty.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtomProperty.java
@@ -61,6 +61,6 @@ public class LabelAtomProperty extends AbstractDescribableImpl<LabelAtomProperty
      * Lists up all the registered {@link LabelAtomPropertyDescriptor}s in the system.
      */
     public static DescriptorExtensionList<LabelAtomProperty,LabelAtomPropertyDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(LabelAtomProperty.class);
+        return Jenkins.get().getDescriptorList(LabelAtomProperty.class);
     }
 }

--- a/core/src/main/java/hudson/model/listeners/SCMListener.java
+++ b/core/src/main/java/hudson/model/listeners/SCMListener.java
@@ -140,12 +140,12 @@ public abstract class SCMListener implements ExtensionPoint {
     /** @deprecated Use {@link Extension} instead. */
     @Deprecated
     public final void register() {
-        Jenkins.getInstance().getSCMListeners().add(this);
+        Jenkins.get().getSCMListeners().add(this);
     }
 
     /** @deprecated Use {@link Extension} instead. */
     @Deprecated
     public final boolean unregister() {
-        return Jenkins.getInstance().getSCMListeners().remove(this);
+        return Jenkins.get().getSCMListeners().remove(this);
     }
 }

--- a/core/src/main/java/hudson/model/queue/BackFiller.java
+++ b/core/src/main/java/hudson/model/queue/BackFiller.java
@@ -34,7 +34,7 @@ public class BackFiller extends LoadPredictor {
         TimeRange timeRange = new TimeRange(start, end - start);
         List<FutureLoad> loads = new ArrayList<>();
 
-        for (BuildableItem bi : Jenkins.getInstance().getQueue().getBuildableItems()) {
+        for (BuildableItem bi : Jenkins.get().getQueue().getBuildableItems()) {
             TentativePlan tp = bi.getAction(TentativePlan.class);
             if (tp==null) {// do this even for bi==plan.item ensures that we have FIFO semantics in tentative plans.
                 tp = makeTentativePlan(bi);
@@ -95,7 +95,7 @@ public class BackFiller extends LoadPredictor {
         try {
             // pretend for now that all executors are available and decide some assignment that's executable.
             List<PseudoExecutorSlot> slots = new ArrayList<>();
-            for (Computer c : Jenkins.getInstance().getComputers()) {
+            for (Computer c : Jenkins.get().getComputers()) {
                 if (c.isOffline())  continue;
                 for (Executor e : c.getExecutors()) {
                     slots.add(new PseudoExecutorSlot(e));
@@ -105,7 +105,7 @@ public class BackFiller extends LoadPredictor {
             // also ignore all load predictions as we just want to figure out some executable assignment
             // and we are not trying to figure out if this task is executable right now.
             MappingWorksheet worksheet = new MappingWorksheet(bi, slots, Collections.emptyList());
-            Mapping m = Jenkins.getInstance().getQueue().getLoadBalancer().map(bi.task, worksheet);
+            Mapping m = Jenkins.get().getQueue().getLoadBalancer().map(bi.task, worksheet);
             if (m==null)    return null;
 
             // figure out how many executors we need on each computer?

--- a/core/src/main/java/hudson/model/queue/FutureImpl.java
+++ b/core/src/main/java/hudson/model/queue/FutureImpl.java
@@ -70,7 +70,7 @@ public final class FutureImpl extends AsyncFutureImpl<Executable> implements Que
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        Queue q = Jenkins.getInstance().getQueue();
+        Queue q = Jenkins.get().getQueue();
         synchronized (q) {
             synchronized (this) {
                 if(!executors.isEmpty()) {

--- a/core/src/main/java/hudson/model/queue/QueueSorter.java
+++ b/core/src/main/java/hudson/model/queue/QueueSorter.java
@@ -74,7 +74,7 @@ public abstract class QueueSorter implements ExtensionPoint {
         ExtensionList<QueueSorter> all = all();
         if (all.isEmpty())  return;
 
-        Queue q = Jenkins.getInstance().getQueue();
+        Queue q = Jenkins.get().getQueue();
         if (q.getSorter()!=null)        return; // someone has already installed something. leave that alone.
 
         q.setSorter(all.get(0));

--- a/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
@@ -83,7 +83,7 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
         Map<Computer,Future<T>> futures = new HashMap<>();
         Set<Computer> skipped = new HashSet<>();
 
-        for (Computer c : Jenkins.getInstance().getComputers()) {
+        for (Computer c : Jenkins.get().getComputers()) {
             try {
                 VirtualChannel ch = c.getChannel();
                 futures.put(c,null);    // sentinel value

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -141,7 +141,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     protected Map<Computer,T> monitor() throws InterruptedException {
         Map<Computer,T> data = new HashMap<>();
-        for( Computer c : Jenkins.getInstance().getComputers() ) {
+        for( Computer c : Jenkins.get().getComputers() ) {
             try {
                 Thread.currentThread().setName("Monitoring "+c.getDisplayName()+" for "+getDisplayName());
 

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -57,7 +57,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
     @Override
     public String getColumnCaption() {
         // Hide this column from non-admins
-        return Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
+        return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
     }
 
     public static final DiskSpaceMonitorDescriptor DESCRIPTOR = new DiskSpaceMonitorDescriptor() {

--- a/core/src/main/java/hudson/node_monitors/NodeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/NodeMonitor.java
@@ -81,7 +81,7 @@ public abstract class NodeMonitor implements ExtensionPoint, Describable<NodeMon
     }
 
     public AbstractNodeMonitorDescriptor<?> getDescriptor() {
-        return (AbstractNodeMonitorDescriptor<?>) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (AbstractNodeMonitorDescriptor<?>) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -146,6 +146,6 @@ public abstract class NodeMonitor implements ExtensionPoint, Describable<NodeMon
      * Returns all the registered {@link NodeMonitor} descriptors.
      */
     public static DescriptorExtensionList<NodeMonitor,Descriptor<NodeMonitor>> all() {
-        return Jenkins.getInstance().getDescriptorList(NodeMonitor.class);
+        return Jenkins.get().getDescriptorList(NodeMonitor.class);
     }
 }

--- a/core/src/main/java/hudson/node_monitors/NodeMonitorUpdater.java
+++ b/core/src/main/java/hudson/node_monitors/NodeMonitorUpdater.java
@@ -24,7 +24,7 @@ public class NodeMonitorUpdater extends ComputerListener {
     private static final Runnable MONITOR_UPDATER = new Runnable() {
         @Override
         public void run() {
-            for (NodeMonitor nm : Jenkins.getInstance().getComputer().getMonitors()) {
+            for (NodeMonitor nm : Jenkins.get().getComputer().getMonitors()) {
                 nm.triggerUpdate();
             }
         }

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -78,7 +78,7 @@ public class SwapSpaceMonitor extends NodeMonitor {
     @Override
     public String getColumnCaption() {
         // Hide this column from non-admins
-        return Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
+        return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
     }
 
     /**

--- a/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
@@ -59,7 +59,7 @@ public class TemporarySpaceMonitor extends AbstractDiskSpaceMonitor {
     @Override
     public String getColumnCaption() {
         // Hide this column from non-admins
-        return Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
+        return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
     }
 
     /**

--- a/core/src/main/java/hudson/os/solaris/ZFSInstaller.java
+++ b/core/src/main/java/hudson/os/solaris/ZFSInstaller.java
@@ -108,7 +108,7 @@ public class ZFSInstaller extends AdministrativeMonitor implements Serializable 
                 return false;       // no active ZFS pool
 
             // if we don't run on a ZFS file system, activate
-            ZFSFileSystem hudsonZfs = zfs.getFileSystemByMountPoint(Jenkins.getInstance().getRootDir());
+            ZFSFileSystem hudsonZfs = zfs.getFileSystemByMountPoint(Jenkins.get().getRootDir());
             if(hudsonZfs!=null)
                 return false;       // already on ZFS
 
@@ -132,7 +132,7 @@ public class ZFSInstaller extends AdministrativeMonitor implements Serializable 
      */
     @RequirePOST
     public HttpResponse doAct(StaplerRequest req) throws ServletException, IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         if(req.hasParameter("n")) {
             // we'll shut up
@@ -165,7 +165,7 @@ public class ZFSInstaller extends AdministrativeMonitor implements Serializable 
             throw new IOException("Failed to obtain the current user information for "+uid);
         final String userName = pwd.pw_name;
 
-        final File home = Jenkins.getInstance().getRootDir();
+        final File home = Jenkins.get().getRootDir();
 
         // this is the actual creation of the file system.
         // return true indicating a success
@@ -233,7 +233,7 @@ public class ZFSInstaller extends AdministrativeMonitor implements Serializable 
      */
     @RequirePOST
     public void doStart(StaplerRequest req, StaplerResponse rsp, @QueryParameter String username, @QueryParameter String password) throws ServletException, IOException {
-        Jenkins hudson = Jenkins.getInstance();
+        Jenkins hudson = Jenkins.get();
         hudson.checkPermission(Jenkins.ADMINISTER);
 
         final String datasetName;
@@ -335,7 +335,7 @@ public class ZFSInstaller extends AdministrativeMonitor implements Serializable 
     private static boolean migrate(TaskListener listener, String target) throws IOException, InterruptedException {
         PrintStream out = listener.getLogger();
 
-        File home = Jenkins.getInstance().getRootDir();
+        File home = Jenkins.get().getRootDir();
         // do the migration
         LibZFS zfs = new LibZFS();
         ZFSFileSystem existing = zfs.getFileSystemByMountPoint(home);

--- a/core/src/main/java/hudson/scm/AutoBrowserHolder.java
+++ b/core/src/main/java/hudson/scm/AutoBrowserHolder.java
@@ -76,7 +76,7 @@ final class AutoBrowserHolder {
      *      null if no applicable configuration was found.
      */
     private RepositoryBrowser infer() {
-        for( AbstractProject p : Jenkins.getInstance().allItems(AbstractProject.class) ) {
+        for( AbstractProject p : Jenkins.get().allItems(AbstractProject.class) ) {
             SCM scm = p.getScm();
             if (scm!=null && scm.getClass()==owner.getClass() && scm.getBrowser()!=null &&
                     ((SCMDescriptor)scm.getDescriptor()).isBrowserReusable(scm,owner)) {

--- a/core/src/main/java/hudson/scm/RepositoryBrowser.java
+++ b/core/src/main/java/hudson/scm/RepositoryBrowser.java
@@ -100,7 +100,7 @@ public abstract class RepositoryBrowser<E extends ChangeLogSet.Entry> extends Ab
      * Returns all the registered {@link RepositoryBrowser} descriptors.
      */
     public static DescriptorExtensionList<RepositoryBrowser<?>,Descriptor<RepositoryBrowser<?>>> all() {
-        return (DescriptorExtensionList) Jenkins.getInstance().getDescriptorList(RepositoryBrowser.class);
+        return (DescriptorExtensionList) Jenkins.get().getDescriptorList(RepositoryBrowser.class);
     }
 
     private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -683,7 +683,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
     public abstract ChangeLogParser createChangeLogParser();
 
     public SCMDescriptor<?> getDescriptor() {
-        return (SCMDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (SCMDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
 //
@@ -727,7 +727,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
      * Returns all the registered {@link SCMDescriptor}s.
      */
     public static DescriptorExtensionList<SCM,SCMDescriptor<?>> all() {
-        return Jenkins.getInstance().<SCM,SCMDescriptor<?>>getDescriptorList(SCM.class);
+        return Jenkins.get().<SCM,SCMDescriptor<?>>getDescriptorList(SCM.class);
     }
 
     /**
@@ -740,7 +740,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
     public static List<SCMDescriptor<?>> _for(@CheckForNull final Job project) {
         if(project==null)   return all();
         
-        final Descriptor pd = Jenkins.getInstance().getDescriptor((Class) project.getClass());
+        final Descriptor pd = Jenkins.get().getDescriptor((Class) project.getClass());
         List<SCMDescriptor<?>> r = new ArrayList<SCMDescriptor<?>>();
         for (SCMDescriptor<?> scmDescriptor : all()) {
             if(!scmDescriptor.isApplicable(project))    continue;

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -413,7 +413,7 @@ public class Search implements StaplerProxy {
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
-            Jenkins.getInstance().checkPermission(Jenkins.READ);
+            Jenkins.get().checkPermission(Jenkins.READ);
         }
         return this;
     }

--- a/core/src/main/java/hudson/security/AbstractPasswordBasedSecurityRealm.java
+++ b/core/src/main/java/hudson/security/AbstractPasswordBasedSecurityRealm.java
@@ -35,7 +35,7 @@ public abstract class AbstractPasswordBasedSecurityRealm extends SecurityRealm i
         binding.setVariable("authenticator", new Authenticator());
 
         BeanBuilder builder = new BeanBuilder();
-        builder.parse(Jenkins.getInstance().servletContext.getResourceAsStream("/WEB-INF/security/AbstractPasswordBasedSecurityRealm.groovy"),binding);
+        builder.parse(Jenkins.get().servletContext.getResourceAsStream("/WEB-INF/security/AbstractPasswordBasedSecurityRealm.groovy"),binding);
         WebApplicationContext context = builder.createApplicationContext();
         return new SecurityComponents(
                 findBean(AuthenticationManager.class, context),

--- a/core/src/main/java/hudson/security/AccessDeniedHandlerImpl.java
+++ b/core/src/main/java/hudson/security/AccessDeniedHandlerImpl.java
@@ -53,7 +53,7 @@ public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
             ((AccessDeniedException2)cause).reportAsHeaders(rsp);
         }
 
-        WebApp.get(Jenkins.getInstance().servletContext).getSomeStapler()
-                .invoke(req,rsp, Jenkins.getInstance(), "/accessDenied");
+        WebApp.get(Jenkins.get().servletContext).getSomeStapler()
+                .invoke(req,rsp, Jenkins.get(), "/accessDenied");
     }
 }

--- a/core/src/main/java/hudson/security/AuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/AuthorizationStrategy.java
@@ -29,18 +29,16 @@ import hudson.ExtensionPoint;
 import hudson.model.*;
 import hudson.slaves.Cloud;
 import hudson.util.DescriptorList;
-
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
-import javax.annotation.Nonnull;
-
 import jenkins.model.Jenkins;
 import jenkins.security.stapler.StaplerAccessibleType;
 import net.sf.json.JSONObject;
-
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Controls authorization throughout Hudson.
@@ -184,7 +182,7 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * Returns all the registered {@link AuthorizationStrategy} descriptors.
      */
     public static @Nonnull DescriptorExtensionList<AuthorizationStrategy,Descriptor<AuthorizationStrategy>> all() {
-        return Jenkins.getInstance().getDescriptorList(AuthorizationStrategy.class);
+        return Jenkins.get().getDescriptorList(AuthorizationStrategy.class);
     }
 
     /**
@@ -233,7 +231,7 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
             }
 
             @Override
-            public @Nonnull AuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            public @Nonnull AuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) {
                 return UNSECURED;
             }
         }

--- a/core/src/main/java/hudson/security/AuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/AuthorizationStrategy.java
@@ -231,7 +231,7 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
             }
 
             @Override
-            public @Nonnull AuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) {
+            public @Nonnull AuthorizationStrategy newInstance(StaplerRequest req, JSONObject formData) throws FormException {
                 return UNSECURED;
             }
         }

--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -102,7 +102,7 @@ public class BasicAuthenticationFilter implements Filter {
 
         String path = req.getServletPath();
         if(authorization==null || req.getUserPrincipal() !=null || path.startsWith("/secured/")
-        || !Jenkins.getInstance().isUseSecurity()) {
+        || !Jenkins.get().isUseSecurity()) {
             // normal requests, or security not enabled
             if(req.getUserPrincipal()!=null) {
                 // before we route this request, integrate the container authentication

--- a/core/src/main/java/hudson/security/ContainerAuthentication.java
+++ b/core/src/main/java/hudson/security/ContainerAuthentication.java
@@ -61,7 +61,7 @@ public final class ContainerAuthentication implements Authentication {
         // Servlet API doesn't provide a way to list up all roles the current user
         // has, so we need to ask AuthorizationStrategy what roles it is going to check against.
         List<GrantedAuthority> l = new ArrayList<>();
-        for( String g : Jenkins.getInstance().getAuthorizationStrategy().getGroups()) {
+        for( String g : Jenkins.get().getAuthorizationStrategy().getGroups()) {
             if(request.isUserInRole(g))
                 l.add(new GrantedAuthorityImpl(g));
         }

--- a/core/src/main/java/hudson/security/FederatedLoginService.java
+++ b/core/src/main/java/hudson/security/FederatedLoginService.java
@@ -189,7 +189,7 @@ public abstract class FederatedLoginService implements ExtensionPoint {
             User u = locateUser();
             if (u!=null) {
                 // login as this user
-                UserDetails d = Jenkins.getInstance().getSecurityRealm().loadUserByUsername(u.getId());
+                UserDetails d = Jenkins.get().getSecurityRealm().loadUserByUsername(u.getId());
 
                 UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(d,"",d.getAuthorities());
                 token.setDetails(d);
@@ -246,7 +246,7 @@ public abstract class FederatedLoginService implements ExtensionPoint {
         }
 
         public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
-            SecurityRealm sr = Jenkins.getInstance().getSecurityRealm();
+            SecurityRealm sr = Jenkins.get().getSecurityRealm();
             if (sr.allowsSignup()) {
                 try {
                     sr.commenceSignup(identity).generateResponse(req,rsp,node);

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -68,11 +68,11 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
     private static final Logger LOGGER = Logger.getLogger(GlobalSecurityConfiguration.class.getName());
 
     public MarkupFormatter getMarkupFormatter() {
-        return Jenkins.getInstance().getMarkupFormatter();
+        return Jenkins.get().getMarkupFormatter();
     }
 
     public int getSlaveAgentPort() {
-        return Jenkins.getInstance().getSlaveAgentPort();
+        return Jenkins.get().getSlaveAgentPort();
     }
 
     /**
@@ -81,25 +81,25 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
      */
     @Restricted(NoExternalUse.class)
     public boolean isSlaveAgentPortEnforced() {
-        return Jenkins.getInstance().isSlaveAgentPortEnforced();
+        return Jenkins.get().isSlaveAgentPortEnforced();
     }
 
     public Set<String> getAgentProtocols() {
-        return Jenkins.getInstance().getAgentProtocols();
+        return Jenkins.get().getAgentProtocols();
     }
 
     public boolean isDisableRememberMe() {
-        return Jenkins.getInstance().isDisableRememberMe();
+        return Jenkins.get().isDisableRememberMe();
     }
 
     @RequirePOST
     public synchronized void doConfigure(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, FormException {
         // for compatibility reasons, the actual value is stored in Jenkins
-        BulkChange bc = new BulkChange(Jenkins.getInstance());
+        BulkChange bc = new BulkChange(Jenkins.get());
         try{
             boolean result = configure(req, req.getSubmittedForm());
             LOGGER.log(Level.FINE, "security saved: "+result);
-            Jenkins.getInstance().save();
+            Jenkins.get().save();
             FormApply.success(req.getContextPath()+"/manage").generateResponse(req, rsp, null);
         } finally {
             bc.commit();
@@ -108,7 +108,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
 
     public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
         // for compatibility reasons, the actual value is stored in Jenkins
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         j.checkPermission(Jenkins.ADMINISTER);
         if (json.has("useSecurity")) {
             JSONObject security = json.getJSONObject("useSecurity");
@@ -201,7 +201,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
     @SuppressWarnings("unchecked")
     @Override
     public Descriptor<GlobalSecurityConfiguration> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
     
     @Extension @Symbol("security")

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -362,7 +362,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      * Try to make this user a super-user
      */
     private void tryToMakeAdmin(User u) {
-        AuthorizationStrategy as = Jenkins.getInstance().getAuthorizationStrategy();
+        AuthorizationStrategy as = Jenkins.get().getAuthorizationStrategy();
         for (PermissionAdder adder : ExtensionList.lookup(PermissionAdder.class)) {
             if (adder.add(as, u, Jenkins.ADMINISTER)) {
                 return;
@@ -471,7 +471,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         if (isMailerPluginPresent()) {
             try {
                 // legacy hack. mail support has moved out to a separate plugin
-                Class<?> up = Jenkins.getInstance().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
+                Class<?> up = Jenkins.get().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
                 Constructor<?> c = up.getDeclaredConstructor(String.class);
                 user.addProperty((UserProperty) c.newInstance(si.email));
             } catch (ReflectiveOperationException e) {
@@ -494,7 +494,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     public boolean isMailerPluginPresent() {
         try {
             // mail support has moved to a separate plugin
-            return null != Jenkins.getInstance().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
+            return null != Jenkins.get().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
         } catch (ClassNotFoundException e) {
             LOGGER.finer("Mailer plugin not present");
         }
@@ -536,15 +536,15 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     }
 
     public ACL getACL() {
-        return Jenkins.getInstance().getACL();
+        return Jenkins.get().getACL();
     }
 
     public void checkPermission(Permission permission) {
-        Jenkins.getInstance().checkPermission(permission);
+        Jenkins.get().checkPermission(permission);
     }
 
     public boolean hasPermission(Permission permission) {
-        return Jenkins.getInstance().hasPermission(permission);
+        return Jenkins.get().hasPermission(permission);
     }
 
 
@@ -737,7 +737,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
             @Override
             public boolean isEnabled() {
                 // this feature is only when HudsonPrivateSecurityRealm is enabled
-                return Jenkins.getInstance().getSecurityRealm() instanceof HudsonPrivateSecurityRealm;
+                return Jenkins.get().getSecurityRealm() instanceof HudsonPrivateSecurityRealm;
             }
 
             public UserProperty newInstance(User user) {
@@ -753,7 +753,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     @Extension @Symbol("localUsers")
     public static final class ManageUserLinks extends ManagementLink {
         public String getIconFileName() {
-            if(Jenkins.getInstance().getSecurityRealm() instanceof HudsonPrivateSecurityRealm)
+            if(Jenkins.get().getSecurityRealm() instanceof HudsonPrivateSecurityRealm)
                 return "user.png";
             else
                 return null;    // not applicable now
@@ -934,7 +934,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
         private boolean needsToCreateFirstUser() {
             return !hasSomeUser()
-                && Jenkins.getInstance().getSecurityRealm() instanceof HudsonPrivateSecurityRealm;
+                && Jenkins.get().getSecurityRealm() instanceof HudsonPrivateSecurityRealm;
         }
 
         public void destroy() {

--- a/core/src/main/java/hudson/security/Permission.java
+++ b/core/src/main/java/hudson/security/Permission.java
@@ -253,7 +253,7 @@ public final class Permission {
 
         try {
             // force the initialization so that it will put all its permissions into the list.
-            Class cl = Class.forName(id.substring(0,idx),true, Jenkins.getInstance().getPluginManager().uberClassLoader);
+            Class cl = Class.forName(id.substring(0,idx),true, Jenkins.get().getPluginManager().uberClassLoader);
             PermissionGroup g = PermissionGroup.get(cl);
             if(g ==null)  return null;
             return g.find(id.substring(idx+1));

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -628,7 +628,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
 
                 So we keep this here.
              */
-            rms.setKey(Jenkins.getInstance().getSecretKey());
+            rms.setKey(Jenkins.get().getSecretKey());
             rms.setParameter("remember_me"); // this is the form field name in login.jelly
             return rms;
         }
@@ -647,7 +647,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      * Returns all the registered {@link SecurityRealm} descriptors.
      */
     public static DescriptorExtensionList<SecurityRealm,Descriptor<SecurityRealm>> all() {
-        return Jenkins.getInstance().getDescriptorList(SecurityRealm.class);
+        return Jenkins.get().getDescriptorList(SecurityRealm.class);
     }
 
 

--- a/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
+++ b/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
@@ -161,7 +161,7 @@ public class TokenBasedRememberMeServices2 extends TokenBasedRememberMeServices 
 
     @Override
     public Authentication autoLogin(HttpServletRequest request, HttpServletResponse response) {
-        if(Jenkins.getInstance().isDisableRememberMe()){
+        if(Jenkins.get().isDisableRememberMe()){
             cancelCookie(request, response, null);
             return null;
         }else {

--- a/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
+++ b/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
@@ -52,7 +52,7 @@ public abstract class CaptchaSupport extends AbstractDescribableImpl<CaptchaSupp
      * Returns all the registered {@link CaptchaSupport} descriptors.
      */
     public static DescriptorExtensionList<CaptchaSupport, Descriptor<CaptchaSupport>> all() {
-        return Jenkins.getInstance().getDescriptorList(CaptchaSupport.class);
+        return Jenkins.get().getDescriptorList(CaptchaSupport.class);
     }
     
     abstract public  boolean validateCaptcha(String id, String text); 

--- a/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
@@ -149,14 +149,14 @@ public abstract class CrumbIssuer implements Describable<CrumbIssuer>, Extension
      * Access global configuration for the crumb issuer.
      */
     public CrumbIssuerDescriptor<CrumbIssuer> getDescriptor() {
-        return (CrumbIssuerDescriptor<CrumbIssuer>) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (CrumbIssuerDescriptor<CrumbIssuer>) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
      * Returns all the registered {@link CrumbIssuer} descriptors.
      */
     public static DescriptorExtensionList<CrumbIssuer, Descriptor<CrumbIssuer>> all() {
-        return Jenkins.getInstance().getDescriptorList(CrumbIssuer.class);
+        return Jenkins.get().getDescriptorList(CrumbIssuer.class);
     }
 
     public Api getApi() {
@@ -168,16 +168,16 @@ public abstract class CrumbIssuer implements Describable<CrumbIssuer>, Extension
      */
     @Initializer
     public static void initStaplerCrumbIssuer() {
-        WebApp.get(Jenkins.getInstance().servletContext).setCrumbIssuer(new org.kohsuke.stapler.CrumbIssuer() {
+        WebApp.get(Jenkins.get().servletContext).setCrumbIssuer(new org.kohsuke.stapler.CrumbIssuer() {
             @Override
             public String issueCrumb(StaplerRequest request) {
-                CrumbIssuer ci = Jenkins.getInstance().getCrumbIssuer();
+                CrumbIssuer ci = Jenkins.get().getCrumbIssuer();
                 return ci!=null ? ci.getCrumb(request) : DEFAULT.issueCrumb(request);
             }
 
             @Override
             public void validateCrumb(StaplerRequest request, String submittedCrumb) {
-                CrumbIssuer ci = Jenkins.getInstance().getCrumbIssuer();
+                CrumbIssuer ci = Jenkins.get().getCrumbIssuer();
                 if (ci==null) {
                     DEFAULT.validateCrumb(request,submittedCrumb);
                 } else {

--- a/core/src/main/java/hudson/slaves/NodePropertyDescriptor.java
+++ b/core/src/main/java/hudson/slaves/NodePropertyDescriptor.java
@@ -53,7 +53,7 @@ public abstract class NodePropertyDescriptor extends PropertyDescriptor<NodeProp
      */
     public boolean isApplicableAsGlobal() {
         // preserve legacy behaviour, even if brain-dead stupid, where applying to Jenkins was the discriminator
-        // note that it would be a mistake to assume Jenkins.getInstance().getClass() == Jenkins.class
+        // note that it would be a mistake to assume Jenkins.get().getClass() == Jenkins.class
         // the groovy code tested against app.class, so we replicate that exact logic.
         return isApplicable(Jenkins.get().getClass());
     }

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -349,7 +349,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     @Extension public static final class Migrator extends ItemListener {
         @SuppressWarnings("deprecation")
         @Override public void onLoaded() {
-            for (AbstractProject<?,?> p : Jenkins.getInstance().allItems(AbstractProject.class)) {
+            for (AbstractProject<?,?> p : Jenkins.get().allItems(AbstractProject.class)) {
                 try {
                     ArtifactArchiver aa = p.getPublishersList().get(ArtifactArchiver.class);
                     if (aa != null && aa.latestOnly != null) {

--- a/core/src/main/java/hudson/tasks/BuildStepDescriptor.java
+++ b/core/src/main/java/hudson/tasks/BuildStepDescriptor.java
@@ -72,7 +72,7 @@ public abstract class BuildStepDescriptor<T extends BuildStep & Describable<T>> 
     public static <T extends BuildStep&Describable<T>>
     List<Descriptor<T>> filter(List<Descriptor<T>> base, Class<? extends AbstractProject> type) {
         // descriptor of the project
-        Descriptor pd = Jenkins.getInstance().getDescriptor((Class) type);
+        Descriptor pd = Jenkins.get().getDescriptor((Class) type);
 
         List<Descriptor<T>> r = new ArrayList<>(base.size());
         for (Descriptor<T> d : base) {

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -146,7 +146,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
      */
     @Deprecated
     public List<AbstractProject> getChildProjects() {
-        return getChildProjects(Jenkins.getInstance());
+        return getChildProjects(Jenkins.get());
     }
 
     /** @deprecated use {@link #getChildJobs} */
@@ -200,7 +200,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
         if (!jobs.isEmpty() && build.getResult().isBetterOrEqualTo(threshold)) {
             PrintStream logger = listener.getLogger();
             for (Job<?, ?> downstream : jobs) {
-                if (Jenkins.getInstance().getItemByFullName(downstream.getFullName()) != downstream) {
+                if (Jenkins.get().getItemByFullName(downstream.getFullName()) != downstream) {
                     LOGGER.log(Level.WARNING, "Running as {0} cannot even see {1} for trigger from {2}", new Object[] {Jenkins.getAuthentication().getName(), downstream, build.getParent()});
                     continue;
                 }
@@ -222,7 +222,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
                     continue;
                 }
                 boolean scheduled = pj.scheduleBuild(pj.getQuietPeriod(), new UpstreamCause((Run) build));
-                if (Jenkins.getInstance().getItemByFullName(downstream.getFullName()) == downstream) {
+                if (Jenkins.get().getItemByFullName(downstream.getFullName()) == downstream) {
                     String name = ModelHyperlinkNote.encodeTo(downstream);
                     if (scheduled) {
                         logger.println(Messages.BuildTrigger_Triggering(name));
@@ -255,7 +255,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
         PrintStream logger = listener.getLogger();
         // Check all downstream Project of the project, not just those defined by BuildTrigger
         // TODO this may not yet be up to date if rebuildDependencyGraphAsync has been used; need a method to wait for the last call made before now to finish
-        final DependencyGraph graph = Jenkins.getInstance().getDependencyGraph();
+        final DependencyGraph graph = Jenkins.get().getDependencyGraph();
         List<Dependency> downstreamProjects = new ArrayList<>(
                 graph.getDownstreamDependencies(build.getProject()));
         // Sort topologically
@@ -276,7 +276,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
                     continue;
                 }
                 boolean scheduled = p.scheduleBuild(p.getQuietPeriod(), new UpstreamCause((Run)build), buildActions.toArray(new Action[0]));
-                if (Jenkins.getInstance().getItemByFullName(p.getFullName()) == p) {
+                if (Jenkins.get().getItemByFullName(p.getFullName()) == p) {
                     String name = ModelHyperlinkNote.encodeTo(p);
                     if (scheduled) {
                         logger.println(Messages.BuildTrigger_Triggering(name));
@@ -297,7 +297,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
                 public boolean shouldTriggerBuild(AbstractBuild build, TaskListener listener,
                                                   List<Action> actions) {
                     AbstractProject downstream = getDownstreamProject();
-                    if (Jenkins.getInstance().getItemByFullName(downstream.getFullName()) != downstream) { // this checks Item.READ also on parent folders
+                    if (Jenkins.get().getItemByFullName(downstream.getFullName()) != downstream) { // this checks Item.READ also on parent folders
                         LOGGER.log(Level.WARNING, "Running as {0} cannot even see {1} for trigger from {2}", new Object[] {Jenkins.getAuthentication().getName(), downstream, getUpstreamProject()});
                         return false; // do not even issue a warning to build log
                     }
@@ -400,7 +400,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
             while(tokens.hasMoreTokens()) {
                 String projectName = tokens.nextToken().trim();
                 if (StringUtils.isNotBlank(projectName)) {
-                    Item item = Jenkins.getInstance().getItem(projectName,project,Item.class);
+                    Item item = Jenkins.get().getItem(projectName,project,Item.class);
                     if (item == null) {
                         Job<?, ?> nearest = Items.findNearest(Job.class, projectName, project.getParent());
                         String alternative = nearest != null ? nearest.getRelativeNameFrom(project) : "?";
@@ -438,7 +438,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
             private void locationChanged(Item item, String oldFullName, String newFullName) {
                 // update BuildTrigger of other projects that point to this object.
                 // can't we generalize this?
-                for( Project<?,?> p : Jenkins.getInstance().allItems(Project.class) ) {
+                for( Project<?,?> p : Jenkins.get().allItems(Project.class) ) {
                     BuildTrigger t = p.getPublishersList().get(BuildTrigger.class);
                     if(t!=null) {
                         String cp2 = Items.computeRelativeNamesAfterRenaming(oldFullName, newFullName, t.childProjects, p.getParent());

--- a/core/src/main/java/hudson/tasks/BuildWrapper.java
+++ b/core/src/main/java/hudson/tasks/BuildWrapper.java
@@ -311,6 +311,6 @@ public abstract class BuildWrapper extends AbstractDescribableImpl<BuildWrapper>
     // for compatibility we can't use BuildWrapperDescriptor
     public static DescriptorExtensionList<BuildWrapper,Descriptor<BuildWrapper>> all() {
         // use getDescriptorList and not getExtensionList to pick up legacy instances
-        return Jenkins.getInstance().getDescriptorList(BuildWrapper.class);
+        return Jenkins.get().getDescriptorList(BuildWrapper.class);
     }
 }

--- a/core/src/main/java/hudson/tasks/BuildWrappers.java
+++ b/core/src/main/java/hudson/tasks/BuildWrappers.java
@@ -56,7 +56,7 @@ public class BuildWrappers {
      */
     public static List<Descriptor<BuildWrapper>> getFor(AbstractProject<?, ?> project) {
         List<Descriptor<BuildWrapper>> result = new ArrayList<>();
-        Descriptor pd = Jenkins.getInstance().getDescriptor((Class)project.getClass());
+        Descriptor pd = Jenkins.get().getDescriptor((Class)project.getClass());
 
         for (Descriptor<BuildWrapper> w : BuildWrapper.all()) {
             if (pd instanceof AbstractProjectDescriptor && !((AbstractProjectDescriptor)pd).isApplicable(w))

--- a/core/src/main/java/hudson/tasks/Builder.java
+++ b/core/src/main/java/hudson/tasks/Builder.java
@@ -64,7 +64,7 @@ public abstract class Builder extends BuildStepCompatibilityLayer implements Des
     }
 
     public Descriptor<Builder> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -72,6 +72,6 @@ public abstract class Builder extends BuildStepCompatibilityLayer implements Des
      */
     // for backward compatibility, the signature is not BuildStepDescriptor
     public static DescriptorExtensionList<Builder,Descriptor<Builder>> all() {
-        return Jenkins.getInstance().getDescriptorList(Builder.class);
+        return Jenkins.get().getDescriptorList(Builder.class);
     }
 }

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -189,7 +189,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
             }
 
             if (enableFingerprintsInDependencyGraph) {
-                Jenkins.getInstance().rebuildDependencyGraphAsync();
+                Jenkins.get().rebuildDependencyGraphAsync();
             }
         } catch (IOException e) {
             Functions.printStackTrace(e, listener.error(Messages.Fingerprinter_Failed()));
@@ -257,7 +257,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
         }
 
         Fingerprint addRecord(Run build) throws IOException {
-            FingerprintMap map = Jenkins.getInstance().getFingerprintMap();
+            FingerprintMap map = Jenkins.get().getFingerprintMap();
             return map.getOrCreate(produced?build:null, fileName, md5sum);
         }
 
@@ -440,7 +440,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
                     return m;
             }
 
-            Jenkins h = Jenkins.getInstance();
+            Jenkins h = Jenkins.get();
 
             Map<String,Fingerprint> m = new TreeMap<>();
             for (Entry<String, String> r : record.entrySet()) {

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -678,14 +678,14 @@ public class Maven extends Builder {
             // newer code need not do this
             @Override
             public MavenInstallation[] getInstallations() {
-                return Jenkins.getInstance().getDescriptorByType(Maven.DescriptorImpl.class).getInstallations();
+                return Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).getInstallations();
             }
 
             // overriding them for backward compatibility.
             // newer code need not do this
             @Override
             public void setInstallations(MavenInstallation... installations) {
-                Jenkins.getInstance().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(installations);
+                Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(installations);
             }
 
             /**

--- a/core/src/main/java/hudson/tasks/Publisher.java
+++ b/core/src/main/java/hudson/tasks/Publisher.java
@@ -119,7 +119,7 @@ public abstract class Publisher extends BuildStepCompatibilityLayer implements D
     }
 
     public Descriptor<Publisher> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -168,6 +168,6 @@ public abstract class Publisher extends BuildStepCompatibilityLayer implements D
      */
     // for backward compatibility, the signature is not BuildStepDescriptor
     public static DescriptorExtensionList<Publisher,Descriptor<Publisher>> all() {
-        return Jenkins.getInstance().getDescriptorList(Publisher.class);
+        return Jenkins.get().getDescriptorList(Publisher.class);
     }
 }

--- a/core/src/main/java/hudson/tasks/UserAvatarResolver.java
+++ b/core/src/main/java/hudson/tasks/UserAvatarResolver.java
@@ -87,7 +87,7 @@ public abstract class UserAvatarResolver implements ExtensionPoint {
      */
     public static String resolve(User u, String avatarSize) {
         String avatar = resolveOrNull(u, avatarSize);
-        return avatar != null ? avatar : Jenkins.getInstance().getRootUrl() + Functions.getResourcePath() + "/images/" + avatarSize + "/user.png";
+        return avatar != null ? avatar : Jenkins.get().getRootUrl() + Functions.getResourcePath() + "/images/" + avatarSize + "/user.png";
     }
 
     /**

--- a/core/src/main/java/hudson/tools/ToolDescriptor.java
+++ b/core/src/main/java/hudson/tools/ToolDescriptor.java
@@ -158,7 +158,7 @@ public abstract class ToolDescriptor<T extends ToolInstallation> extends Descrip
      */
     public FormValidation doCheckHome(@QueryParameter File value) {
         // this can be used to check the existence of a file on the server, so needs to be protected
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         if (value.getPath().isEmpty()) {
             return FormValidation.ok();

--- a/core/src/main/java/hudson/tools/ToolInstallation.java
+++ b/core/src/main/java/hudson/tools/ToolInstallation.java
@@ -241,7 +241,7 @@ public abstract class ToolInstallation extends AbstractDescribableImpl<ToolInsta
      */
     public static DescriptorExtensionList<ToolInstallation,ToolDescriptor<?>> all() {
         // use getDescriptorList and not getExtensionList to pick up legacy instances
-        return Jenkins.getInstance().getDescriptorList(ToolInstallation.class);
+        return Jenkins.get().getDescriptorList(ToolInstallation.class);
     }
 
     private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/tools/ToolInstaller.java
+++ b/core/src/main/java/hudson/tools/ToolInstaller.java
@@ -85,7 +85,7 @@ public abstract class ToolInstaller implements Describable<ToolInstaller>, Exten
      * (By default, just checks the label.)
      */
     public boolean appliesTo(Node node) {
-        Label l = Jenkins.getInstance().getLabel(label);
+        Label l = Jenkins.get().getLabel(label);
         return l == null || l.contains(node);
     }
 
@@ -131,7 +131,7 @@ public abstract class ToolInstaller implements Describable<ToolInstaller>, Exten
     }
 
     public ToolInstallerDescriptor<?> getDescriptor() {
-        return (ToolInstallerDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (ToolInstallerDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/hudson/tools/ToolInstallerDescriptor.java
+++ b/core/src/main/java/hudson/tools/ToolInstallerDescriptor.java
@@ -48,7 +48,7 @@ public abstract class ToolInstallerDescriptor<T extends ToolInstaller> extends D
     }
 
     public static DescriptorExtensionList<ToolInstaller,ToolInstallerDescriptor<?>> all() {
-        return Jenkins.getInstance().getDescriptorList(ToolInstaller.class);
+        return Jenkins.get().getDescriptorList(ToolInstaller.class);
     }
 
     /**

--- a/core/src/main/java/hudson/tools/ToolProperty.java
+++ b/core/src/main/java/hudson/tools/ToolProperty.java
@@ -56,7 +56,7 @@ public abstract class ToolProperty<T extends ToolInstallation> implements Descri
     }
 
     public ToolPropertyDescriptor getDescriptor() {
-        return (ToolPropertyDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (ToolPropertyDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -70,6 +70,6 @@ public abstract class ToolProperty<T extends ToolInstallation> implements Descri
      * @see ToolDescriptor#getPropertyDescriptors() 
      */
     public static DescriptorExtensionList<ToolProperty<?>,ToolPropertyDescriptor> all() {
-        return (DescriptorExtensionList) Jenkins.getInstance().getDescriptorList(ToolProperty.class);
+        return (DescriptorExtensionList) Jenkins.get().getDescriptorList(ToolProperty.class);
     }
 }

--- a/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
+++ b/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
@@ -99,7 +99,7 @@ public class ZipExtractionInstaller extends ToolInstaller {
 
         @RequirePOST
         public FormValidation doCheckUrl(@QueryParameter String value) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             
             try {
                 URLConnection conn = ProxyConfiguration.open(new URL(value));

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -333,7 +333,7 @@ public class SCMTrigger extends Trigger<Item> {
             int count = 0;
             // we are faster walking some items with a lazy iterator than building a list of all items just to query
             // the size. This also lets us check against SCMTriggerItem rather than AbstractProject
-            for (Item item: Jenkins.getInstance().allItems(Item.class)) {
+            for (Item item: Jenkins.get().allItems(Item.class)) {
                 if (item instanceof SCMTriggerItem) {
                     if (++count > 10) {
                         return true;
@@ -383,7 +383,7 @@ public class SCMTrigger extends Trigger<Item> {
                     return FormValidation.ok(Messages.SCMTrigger_no_schedules_hooks());
                 }
             } else {
-                return Jenkins.getInstance().getDescriptorByType(TimerTrigger.DescriptorImpl.class)
+                return Jenkins.get().getDescriptorByType(TimerTrigger.DescriptorImpl.class)
                         .doCheckSpec(value, item);
             }
         }

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -150,7 +150,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
     }
 
     public TriggerDescriptor getDescriptor() {
-        return (TriggerDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (TriggerDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
 
@@ -237,7 +237,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
     private static Future previousSynchronousPolling;
 
     public static void checkTriggers(final Calendar cal) {
-        Jenkins inst = Jenkins.getInstance();
+        Jenkins inst = Jenkins.get();
 
         // Are we using synchronous polling?
         SCMTrigger.DescriptorImpl scmd = inst.getDescriptorByType(SCMTrigger.DescriptorImpl.class);
@@ -312,7 +312,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
      * Returns all the registered {@link Trigger} descriptors.
      */
     public static DescriptorExtensionList<Trigger<?>,TriggerDescriptor> all() {
-        return (DescriptorExtensionList) Jenkins.getInstance().getDescriptorList(Trigger.class);
+        return (DescriptorExtensionList) Jenkins.get().getDescriptorList(Trigger.class);
     }
 
     /**

--- a/core/src/main/java/hudson/util/DescriptorList.java
+++ b/core/src/main/java/hudson/util/DescriptorList.java
@@ -146,7 +146,7 @@ public final class DescriptorList<T extends Describable<T>> extends AbstractList
         if(type==null)
             return legacy;
         else
-            return Jenkins.getInstance().getDescriptorList(type);
+            return Jenkins.get().getDescriptorList(type);
     }
 
     /**

--- a/core/src/main/java/hudson/util/DoubleLaunchChecker.java
+++ b/core/src/main/java/hudson/util/DoubleLaunchChecker.java
@@ -91,7 +91,7 @@ public class DoubleLaunchChecker {
     private String collidingId;
 
     public DoubleLaunchChecker() {
-        home = Jenkins.getInstance().getRootDir();
+        home = Jenkins.get().getRootDir();
     }
 
     protected void execute() {
@@ -106,7 +106,7 @@ public class DoubleLaunchChecker {
             }
             // we noticed that someone else have updated this file.
             // switch GUI to display this error.
-            Jenkins.getInstance().servletContext.setAttribute("app",this);
+            Jenkins.get().servletContext.setAttribute("app",this);
             LOGGER.severe("Collision detected. timestamp="+t+", expected="+lastWriteTime);
             // we need to continue updating this file, so that the other Hudson would notice the problem, too.
         }
@@ -126,7 +126,7 @@ public class DoubleLaunchChecker {
      * Figures out a string that identifies this instance of Hudson.
      */
     public String getId() {
-        Jenkins h = Jenkins.getInstance();
+        Jenkins h = Jenkins.get();
 
         // in servlet 2.5, we can get the context path
         String contextPath="";
@@ -178,7 +178,7 @@ public class DoubleLaunchChecker {
     @RequirePOST
     public void doIgnore(StaplerRequest req, StaplerResponse rsp) throws IOException {
         ignore = true;
-        Jenkins.getInstance().servletContext.setAttribute("app", Jenkins.getInstance());
+        Jenkins.get().servletContext.setAttribute("app", Jenkins.get());
         rsp.sendRedirect2(req.getContextPath()+'/');
     }
 

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -85,7 +85,7 @@ public abstract class FormFieldValidator {
      *      information or run a process that may have side-effect.
      */
     protected FormFieldValidator(StaplerRequest request, StaplerResponse response, boolean adminOnly) {
-        this(request, response, adminOnly? Jenkins.getInstance():null, adminOnly?CHECK:null);
+        this(request, response, adminOnly? Jenkins.get():null, adminOnly?CHECK:null);
     }
 
     /**
@@ -95,7 +95,7 @@ public abstract class FormFieldValidator {
      */
     @Deprecated
     protected FormFieldValidator(StaplerRequest request, StaplerResponse response, Permission permission) {
-        this(request,response, Jenkins.getInstance(),permission);
+        this(request,response, Jenkins.get(),permission);
     }
 
     /**
@@ -135,7 +135,7 @@ public abstract class FormFieldValidator {
             } catch (AccessDeniedException e) {
                 // if the user has hudson-wide admin permission, all checks are allowed
                 // this is to protect Hudson administrator from broken ACL/SecurityRealm implementation/configuration.
-                if(!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
+                if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                     throw e;
             }
 

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -332,7 +332,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
      */
     public static FormValidation validateExecutable(String exe, FileValidator exeValidator) {
         // insufficient permission to perform validation?
-        if(!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) return ok();
+        if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) return ok();
 
         exe = fixEmpty(exe);
         if(exe==null)

--- a/core/src/main/java/hudson/util/HistoricalSecrets.java
+++ b/core/src/main/java/hudson/util/HistoricalSecrets.java
@@ -82,7 +82,7 @@ public class HistoricalSecrets {
     @Deprecated
     /*package*/ static SecretKey getLegacyKey() throws GeneralSecurityException {
         String secret = Secret.SECRET;
-        if(secret==null)    return Jenkins.getInstance().getSecretKeyAsAES128();
+        if(secret==null)    return Jenkins.get().getSecretKeyAsAES128();
         return Util.toAes128Key(secret);
     }
 

--- a/core/src/main/java/hudson/util/PluginServletFilter.java
+++ b/core/src/main/java/hudson/util/PluginServletFilter.java
@@ -65,7 +65,7 @@ public class PluginServletFilter implements Filter, ExtensionPoint {
     private /*almost final*/ FilterConfig config;
 
     /**
-     * For backward compatibility with plugins that might register filters before Jenkins.getInstance()
+     * For backward compatibility with plugins that might register filters before Jenkins.get()
      * starts functioning, when we are not sure which Jenkins instance a filter belongs to, put it here,
      * and let the first Jenkins instance take over.
      */

--- a/core/src/main/java/hudson/util/RemotingDiagnostics.java
+++ b/core/src/main/java/hudson/util/RemotingDiagnostics.java
@@ -121,7 +121,7 @@ public final class RemotingDiagnostics {
         }
 
         public ClassLoader getClassLoader() {
-            return Jenkins.getInstance().getPluginManager().uberClassLoader;
+            return Jenkins.get().getPluginManager().uberClassLoader;
         }
 
         public String call() throws RuntimeException {

--- a/core/src/main/java/hudson/views/ListViewColumn.java
+++ b/core/src/main/java/hudson/views/ListViewColumn.java
@@ -87,7 +87,7 @@ public abstract class ListViewColumn implements ExtensionPoint, Describable<List
      * Returns all the registered {@link ListViewColumn} descriptors.
      */
     public static DescriptorExtensionList<ListViewColumn, Descriptor<ListViewColumn>> all() {
-        return Jenkins.getInstance().getDescriptorList(ListViewColumn.class);
+        return Jenkins.get().getDescriptorList(ListViewColumn.class);
     }
 
     /**
@@ -116,7 +116,7 @@ public abstract class ListViewColumn implements ExtensionPoint, Describable<List
      * and instead return a plain {@link Descriptor} instance.
      */
     public Descriptor<ListViewColumn> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**

--- a/core/src/main/java/hudson/views/MyViewsTabBar.java
+++ b/core/src/main/java/hudson/views/MyViewsTabBar.java
@@ -64,7 +64,7 @@ public abstract class MyViewsTabBar extends AbstractDescribableImpl<MyViewsTabBa
      * Returns all the registered {@link ListViewColumn} descriptors.
      */
     public static DescriptorExtensionList<MyViewsTabBar, Descriptor<MyViewsTabBar>> all() {
-        return Jenkins.getInstance().getDescriptorList(MyViewsTabBar.class);
+        return Jenkins.get().getDescriptorList(MyViewsTabBar.class);
     }
 
     public MyViewsTabBarDescriptor getDescriptor() {

--- a/core/src/main/java/hudson/views/ViewJobFilter.java
+++ b/core/src/main/java/hudson/views/ViewJobFilter.java
@@ -44,12 +44,12 @@ public abstract class ViewJobFilter implements ExtensionPoint, Describable<ViewJ
      * Returns all the registered {@link ViewJobFilter} descriptors.
      */
     public static DescriptorExtensionList<ViewJobFilter, Descriptor<ViewJobFilter>> all() {
-        return Jenkins.getInstance().getDescriptorList(ViewJobFilter.class);
+        return Jenkins.get().getDescriptorList(ViewJobFilter.class);
     }
 
     @SuppressWarnings("unchecked")
 	public Descriptor<ViewJobFilter> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return Jenkins.get().getDescriptorOrDie(getClass());
     }
     
     /**

--- a/core/src/main/java/hudson/views/ViewsTabBar.java
+++ b/core/src/main/java/hudson/views/ViewsTabBar.java
@@ -65,7 +65,7 @@ public abstract class ViewsTabBar extends AbstractDescribableImpl<ViewsTabBar> i
      * Returns all the registered {@link ViewsTabBar} descriptors.
      */
     public static DescriptorExtensionList<ViewsTabBar, Descriptor<ViewsTabBar>> all() {
-        return Jenkins.getInstance().getDescriptorList(ViewsTabBar.class);
+        return Jenkins.get().getDescriptorList(ViewsTabBar.class);
     }
 
     @Override

--- a/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
@@ -53,7 +53,7 @@ public class BuildHistoryWidget<T> extends HistoryWidget<Task,T> {
      * Returns the first queue item if the owner is scheduled for execution in the queue.
      */
     public Item getQueuedItem() {
-        return Jenkins.getInstance().getQueue().getItem(owner);
+        return Jenkins.get().getQueue().getItem(owner);
     }
 
     /**
@@ -61,7 +61,7 @@ public class BuildHistoryWidget<T> extends HistoryWidget<Task,T> {
      */
     public List<Item> getQueuedItems() {
         LinkedList<Item> list = new LinkedList<>();
-        for (Item item : Jenkins.getInstance().getQueue().getItems()) {
+        for (Item item : Jenkins.get().getQueue().getItems()) {
             if (item.task == owner) {
                 list.addFirst(item);
             }

--- a/core/src/main/java/jenkins/diagnosis/HsErrPidFile.java
+++ b/core/src/main/java/jenkins/diagnosis/HsErrPidFile.java
@@ -45,13 +45,13 @@ public class HsErrPidFile {
     }
 
     public HttpResponse doDownload() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         return HttpResponses.staticResource(file);
     }
 
     @RequirePOST
     public HttpResponse doDelete() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         file.delete();
         owner.files.remove(this);
         return HttpResponses.redirectTo("../..");

--- a/core/src/main/java/jenkins/diagnosis/HsErrPidList.java
+++ b/core/src/main/java/jenkins/diagnosis/HsErrPidList.java
@@ -151,7 +151,7 @@ public class HsErrPidList extends AdministrativeMonitor {
     }
 
     private File getSecretKeyFile() {
-        return new File(Jenkins.getInstance().getRootDir(),"secret.key");
+        return new File(Jenkins.get().getRootDir(),"secret.key");
     }
 
     private boolean findHeader(BufferedReader r) throws IOException {

--- a/core/src/main/java/jenkins/diagnostics/CompletedInitializationMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/CompletedInitializationMonitor.java
@@ -48,7 +48,7 @@ public class CompletedInitializationMonitor extends AdministrativeMonitor {
 
     @Override
     public boolean isActivated() {
-        final Jenkins instance = Jenkins.getInstance();
+        final Jenkins instance = Jenkins.get();
         // Safe to check in such way, because monitors are being checked in UI only.
         // So Jenkins class construction and initialization must be always finished by the call of this extension.
         return instance.getInitLevel() != InitMilestone.COMPLETED;

--- a/core/src/main/java/jenkins/diagnostics/SecurityIsOffMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/SecurityIsOffMonitor.java
@@ -29,7 +29,7 @@ public class SecurityIsOffMonitor extends AdministrativeMonitor {
 
     @Override
     public boolean isActivated() {
-        return !Jenkins.getInstance().isUseSecurity();
+        return !Jenkins.get().isUseSecurity();
     }
 
     /**

--- a/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
@@ -8,6 +8,8 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.io.IOException;
+
 import static hudson.Util.fixEmpty;
 
 @Restricted(NoExternalUse.class)
@@ -28,7 +30,7 @@ public class URICheckEncodingMonitor extends AdministrativeMonitor {
         return Messages.URICheckEncodingMonitor_DisplayName();
     }
 
-    public FormValidation doCheckURIEncoding(StaplerRequest request) {
+    public FormValidation doCheckURIEncoding(StaplerRequest request) throws IOException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         // expected is non-ASCII String
         final String expected = "\u57f7\u4e8b";

--- a/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
@@ -1,14 +1,12 @@
 package jenkins.diagnostics;
 
 import hudson.Extension;
-import hudson.model.*;
+import hudson.model.AdministrativeMonitor;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
-
-import java.io.IOException;
 
 import static hudson.Util.fixEmpty;
 
@@ -30,8 +28,8 @@ public class URICheckEncodingMonitor extends AdministrativeMonitor {
         return Messages.URICheckEncodingMonitor_DisplayName();
     }
 
-    public FormValidation doCheckURIEncoding(StaplerRequest request) throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+    public FormValidation doCheckURIEncoding(StaplerRequest request) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         // expected is non-ASCII String
         final String expected = "\u57f7\u4e8b";
         final String value = fixEmpty(request.getParameter("value"));

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -93,7 +93,7 @@ public class InstallUtil {
     public static void proceedToNextStateFrom(InstallState prior) {
         InstallState next = getNextInstallState(prior);
         if (next != null) {
-            Jenkins.getInstance().setInstallState(next);
+            Jenkins.get().setInstallState(next);
         }
     }
     
@@ -162,7 +162,7 @@ public class InstallUtil {
         // Neither the top level config or the lastExecVersionFile have a version
         // stored in them, which means it's a new install.
         if (FORCE_NEW_INSTALL_VERSION.equals(lastRunVersion) || lastRunVersion.compareTo(NEW_INSTALL_VERSION) == 0) {
-            Jenkins j = Jenkins.getInstance();
+            Jenkins j = Jenkins.get();
             
             // Allow for skipping
             if(shouldNotRun) {
@@ -274,15 +274,15 @@ public class InstallUtil {
     }
 
     static File getConfigFile() {
-        return new File(Jenkins.getInstance().getRootDir(), "config.xml");
+        return new File(Jenkins.get().getRootDir(), "config.xml");
     }
 
     static File getLastExecVersionFile() {
-        return new File(Jenkins.getInstance().getRootDir(), "jenkins.install.InstallUtil.lastExecVersion");
+        return new File(Jenkins.get().getRootDir(), "jenkins.install.InstallUtil.lastExecVersion");
     }
 
     static File getInstallingPluginsFile() {
-        return new File(Jenkins.getInstance().getRootDir(), "jenkins.install.InstallUtil.installingPlugins");
+        return new File(Jenkins.get().getRootDir(), "jenkins.install.InstallUtil.installingPlugins");
     }
 
     private static String getCurrentExecVersion() {

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -237,7 +237,7 @@ public class SetupWizard extends PageDecorator {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public HttpResponse doCreateAdminUser(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
 
         j.checkPermission(Jenkins.ADMINISTER);
 
@@ -281,7 +281,7 @@ public class SetupWizard extends PageDecorator {
             // include the new seed
             newSession.setAttribute(UserSeedProperty.USER_SESSION_SEED, sessionSeed);
             
-            CrumbIssuer crumbIssuer = Jenkins.getInstance().getCrumbIssuer();
+            CrumbIssuer crumbIssuer = Jenkins.get().getCrumbIssuer();
             JSONObject data = new JSONObject();
             if (crumbIssuer != null) {
                 data.accumulate("crumbRequestField", crumbIssuer.getCrumbRequestField()).accumulate("crumb", crumbIssuer.getCrumb(req));

--- a/core/src/main/java/jenkins/install/UpgradeWizard.java
+++ b/core/src/main/java/jenkins/install/UpgradeWizard.java
@@ -65,8 +65,8 @@ public class UpgradeWizard extends InstallState {
         
         // If there are no platform updates, proceed to running
         if (isUpToDate) {
-            if (Jenkins.getInstance().getSetupWizard().getPlatformPluginUpdates().isEmpty()) {
-                Jenkins.getInstance().setInstallState(InstallState.RUNNING);
+            if (Jenkins.get().getSetupWizard().getPlatformPluginUpdates().isEmpty()) {
+                Jenkins.get().setInstallState(InstallState.RUNNING);
             }
         }
     }
@@ -95,7 +95,7 @@ public class UpgradeWizard extends InstallState {
         // If we don't have any platform plugins, it's considered 'up to date' in terms
         // of the updater
         try {
-            JSONArray platformPlugins = Jenkins.getInstance().getSetupWizard().getPlatformPluginUpdates();
+            JSONArray platformPlugins = Jenkins.get().getSetupWizard().getPlatformPluginUpdates();
             isUpToDate = platformPlugins.isEmpty();
         } catch(Exception e) {
             LOGGER.log(Level.WARNING, "Unable to get the platform plugin update list.", e);
@@ -110,7 +110,7 @@ public class UpgradeWizard extends InstallState {
             return false;
 
         // only admin users should see this
-        if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
+        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
             return false;
 
         // only show when Jenkins is fully up & running
@@ -135,7 +135,7 @@ public class UpgradeWizard extends InstallState {
      * Call this to show the upgrade wizard
      */
     public HttpResponse doShowUpgradeWizard() throws Exception {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         HttpSession session = Stapler.getCurrentRequest().getSession(true);
         session.setAttribute(SHOW_UPGRADE_WIZARD_FLAG, true);
         return HttpResponses.redirectToContextRoot();
@@ -145,7 +145,7 @@ public class UpgradeWizard extends InstallState {
      * Call this to hide the upgrade wizard
      */
     public HttpResponse doHideUpgradeWizard() {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         HttpSession session = Stapler.getCurrentRequest().getSession(false);
         if(session != null) {
             session.removeAttribute(SHOW_UPGRADE_WIZARD_FLAG);
@@ -158,7 +158,7 @@ public class UpgradeWizard extends InstallState {
      */
     @RequirePOST
     public HttpResponse doSnooze() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         File f = SetupWizard.getUpdateStateFile();
         FileUtils.touch(f);
         f.setLastModified(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -74,7 +74,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
 
     public Collection<AdministrativeMonitor> getActiveAdministrativeMonitors() {
         Collection<AdministrativeMonitor> active = new ArrayList<>();
-        for (AdministrativeMonitor am : Jenkins.getInstance().getActiveAdministrativeMonitors()) {
+        for (AdministrativeMonitor am : Jenkins.get().getActiveAdministrativeMonitors()) {
             if (am instanceof ReverseProxySetupMonitor) {
                 // TODO make reverse proxy monitor work when shown on any URL
                 continue;
@@ -90,7 +90,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
 
     /**
      * Whether the administrative monitors notifier should be shown.
-     * @return true iff the administrative monitors notifier should be shown.
+     * @return true if the administrative monitors notifier should be shown.
      * @throws IOException
      * @throws ServletException
      */
@@ -107,7 +107,6 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
         List<Ancestor> ancestors = req.getAncestors();
 
         if (ancestors == null || ancestors.size() == 0) {
-            // ???
             return false;
         }
 
@@ -115,11 +114,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
         Object o = a.getObject();
 
         // don't show while Jenkins is loading
-        if (o instanceof HudsonIsLoading) {
-            return false;
-        }
-        // … or restarting
-        if (o instanceof HudsonIsRestarting) {
+        if (o instanceof HudsonIsLoading || o instanceof HudsonIsRestarting) {
             return false;
         }
 

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -90,7 +90,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
 
     /**
      * Whether the administrative monitors notifier should be shown.
-     * @return true if the administrative monitors notifier should be shown.
+     * @return true iff the administrative monitors notifier should be shown.
      * @throws IOException
      * @throws ServletException
      */
@@ -107,6 +107,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
         List<Ancestor> ancestors = req.getAncestors();
 
         if (ancestors == null || ancestors.size() == 0) {
+            // ???
             return false;
         }
 

--- a/core/src/main/java/jenkins/management/AsynchronousAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/management/AsynchronousAdministrativeMonitor.java
@@ -62,7 +62,7 @@ public abstract class AsynchronousAdministrativeMonitor extends AdministrativeMo
     }
 
     protected File getBaseDir() {
-        return new File(Jenkins.getInstance().getRootDir(),getClass().getName());
+        return new File(Jenkins.get().getRootDir(),getClass().getName());
     }
 
     public abstract String getDisplayName();

--- a/core/src/main/java/jenkins/management/ShutdownLink.java
+++ b/core/src/main/java/jenkins/management/ShutdownLink.java
@@ -41,17 +41,17 @@ public class ShutdownLink extends ManagementLink {
     }
 
     public String getDisplayName() {
-        return Jenkins.getInstance().isQuietingDown() ? Messages.ShutdownLink_DisplayName_cancel() : Messages.ShutdownLink_DisplayName_prepare();
+        return Jenkins.get().isQuietingDown() ? Messages.ShutdownLink_DisplayName_cancel() : Messages.ShutdownLink_DisplayName_prepare();
     }
 
     @Override
     public String getDescription() {
-        return Jenkins.getInstance().isQuietingDown() ? "" : Messages.ShutdownLink_Description();
+        return Jenkins.get().isQuietingDown() ? "" : Messages.ShutdownLink_Description();
     }
 
     @Override
     public String getUrlName() {
-        return Jenkins.getInstance().isQuietingDown() ? "cancelQuietDown" : "quietDown";
+        return Jenkins.get().isQuietingDown() ? "cancelQuietDown" : "quietDown";
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/AbstractTopLevelItem.java
+++ b/core/src/main/java/jenkins/model/AbstractTopLevelItem.java
@@ -25,6 +25,6 @@ public abstract class AbstractTopLevelItem extends AbstractItem implements TopLe
     }
 
     public TopLevelItemDescriptor getDescriptor() {
-        return (TopLevelItemDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (TopLevelItemDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 }

--- a/core/src/main/java/jenkins/model/ArtifactManagerFactoryDescriptor.java
+++ b/core/src/main/java/jenkins/model/ArtifactManagerFactoryDescriptor.java
@@ -35,7 +35,7 @@ import hudson.model.Descriptor;
 public abstract class ArtifactManagerFactoryDescriptor extends Descriptor<ArtifactManagerFactory> {
 
     public static DescriptorExtensionList<ArtifactManagerFactory,ArtifactManagerFactoryDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(ArtifactManagerFactory.class);
+        return Jenkins.get().getDescriptorList(ArtifactManagerFactory.class);
     }
 
 }

--- a/core/src/main/java/jenkins/model/BuildDiscarderDescriptor.java
+++ b/core/src/main/java/jenkins/model/BuildDiscarderDescriptor.java
@@ -20,6 +20,6 @@ public abstract class BuildDiscarderDescriptor extends Descriptor<BuildDiscarder
      * Returns all the registered {@link BuildDiscarderDescriptor}s.
      */
     public static DescriptorExtensionList<BuildDiscarder,BuildDiscarderDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(BuildDiscarder.class);
+        return Jenkins.get().getDescriptorList(BuildDiscarder.class);
     }
 }

--- a/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
+++ b/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
@@ -32,7 +32,7 @@ public class CoreEnvironmentContributor extends EnvironmentContributor {
         }
         env.put("BUILD_DISPLAY_NAME",r.getDisplayName());
 
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         String rootUrl = j.getRootUrl();
         if(rootUrl!=null) {
             env.put("BUILD_URL", rootUrl+r.getUrl());
@@ -41,7 +41,7 @@ public class CoreEnvironmentContributor extends EnvironmentContributor {
 
     @Override
     public void buildEnvironmentFor(Job j, EnvVars env, TaskListener listener) throws IOException, InterruptedException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         String rootUrl = jenkins.getRootUrl();
         if(rootUrl!=null) {
             env.put("JENKINS_URL", rootUrl);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -515,7 +515,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         @Override
         protected void onModified() throws IOException {
             super.onModified();
-            Jenkins.getInstance().trimLabels();
+            Jenkins.get().trimLabels();
         }
     }
 
@@ -742,7 +742,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
 
     /**
-     * Hook for a test harness to intercept Jenkins.getInstance()
+     * Hook for a test harness to intercept Jenkins.get()
      *
      * Do not use in the production code as the signature may change.
      */
@@ -1305,7 +1305,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         @Override
         public boolean isActivated() {
-            int slaveAgentPort = Jenkins.getInstance().slaveAgentPort;
+            int slaveAgentPort = Jenkins.get().slaveAgentPort;
             return SLAVE_AGENT_PORT_ENFORCE && slaveAgentPort != Jenkins.getSlaveAgentPortInitialValue(slaveAgentPort);
         }
     }
@@ -1707,7 +1707,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * <p>
      * To register an {@link Action}, implement {@link RootAction} extension point, or write code like
-     * {@code Jenkins.getInstance().getActions().add(...)}.
+     * {@code Jenkins.get().getActions().add(...)}.
      *
      * @return
      *      Live list where the changes can be made. Can be empty but never null.
@@ -2173,7 +2173,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         // to route /descriptor/FQCN/xxx to getDescriptor(FQCN).xxx
         public Object getDynamic(String token) {
-            return Jenkins.getInstance().getDescriptor(token);
+            return Jenkins.get().getDescriptor(token);
         }
     }
 
@@ -2269,7 +2269,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         final JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();
         if (config == null) {
             // Try to get standard message if possible
-            final Jenkins j = Jenkins.getInstance();
+            final Jenkins j = Jenkins.get();
             throw new IllegalStateException("Jenkins instance " + j + " has been successfully initialized, but JenkinsLocationConfiguration is undefined.");
         }
         String url = config.getUrl();
@@ -2410,7 +2410,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @Restricted(NoExternalUse.class)
     public static String expandVariablesForDirectory(String base, String itemFullName, String itemRootDir) {
         return Util.replaceMacro(base, ImmutableMap.of(
-                "JENKINS_HOME", Jenkins.getInstance().getRootDir().getPath(),
+                "JENKINS_HOME", Jenkins.get().getRootDir().getPath(),
                 "ITEM_ROOTDIR", itemRootDir,
                 "ITEM_FULLNAME", itemFullName,   // legacy, deprecated
                 "ITEM_FULL_NAME", itemFullName.replace(':','$'))); // safe, see JENKINS-12251
@@ -3090,7 +3090,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         // do essentially what expandVariablesForDirectory does, without an Item
         String replacedValue = expandVariablesForDirectory(newBuildsDirValue,
                                                            "doCheckRawBuildsDir-Marker:foo",
-                                                           Jenkins.getInstance().getRootDir().getPath() + "/jobs/doCheckRawBuildsDir-Marker$foo");
+                                                           Jenkins.get().getRootDir().getPath() + "/jobs/doCheckRawBuildsDir-Marker$foo");
 
         File replacedFile = new File(replacedValue);
         if (!replacedFile.isAbsolute()) {
@@ -4296,7 +4296,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         @Override
         public void onRestart() {
-            Computer computer = Jenkins.getInstance().toComputer();
+            Computer computer = Jenkins.get().toComputer();
             if (computer == null) return;
             RestartCause cause = new RestartCause();
             for (ComputerListener listener: ComputerListener.all()) {
@@ -4840,7 +4840,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     public static class MasterComputer extends Computer {
         protected MasterComputer() {
-            super(Jenkins.getInstance());
+            super(Jenkins.get());
         }
 
         /**
@@ -4900,7 +4900,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         @Override
         @RequirePOST
         public void doConfigSubmit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, FormException {
-            Jenkins.getInstance().doConfigExecutorsSubmit(req, rsp);
+            Jenkins.get().doConfigExecutorsSubmit(req, rsp);
         }
 
         @WebMethod(name="config.xml")

--- a/core/src/main/java/jenkins/model/NewViewLink.java
+++ b/core/src/main/java/jenkins/model/NewViewLink.java
@@ -44,7 +44,7 @@ public class NewViewLink extends TransientViewActionFactory {
 
             @Override
             public String getUrlName() {
-                return Jenkins.getInstance().getRootUrl() + URL_NAME;
+                return Jenkins.get().getRootUrl() + URL_NAME;
             }
 
             private boolean hasPermission(View view) {

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -153,7 +153,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         if (isParameterized() && Util.filter(queueActions, ParametersAction.class).isEmpty()) {
             queueActions.add(new ParametersAction(getDefaultParametersValues()));
         }
-        return Jenkins.getInstance().getQueue().schedule2(asJob(), quietPeriod, queueActions).getItem();
+        return Jenkins.get().getQueue().schedule2(asJob(), quietPeriod, queueActions).getItem();
     }
 
     private List<ParameterValue> getDefaultParametersValues() {
@@ -214,7 +214,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         }
 
 
-        Queue.Item item = Jenkins.getInstance().getQueue().schedule2(asJob(), delay.getTimeInSeconds(), getBuildCause(asJob(), req)).getItem();
+        Queue.Item item = Jenkins.get().getQueue().schedule2(asJob(), delay.getTimeInSeconds(), getBuildCause(asJob(), req)).getItem();
         if (item != null) {
             rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + item.getUrl());
         } else {
@@ -246,7 +246,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
     @RequirePOST
     public final void doCancelQueue( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
         asJob().checkPermission(Item.CANCEL);
-        Jenkins.getInstance().getQueue().cancel(asJob());
+        Jenkins.get().getQueue().cancel(asJob());
         rsp.forwardToPreviousPage(req);
     }
 
@@ -327,9 +327,9 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         @SuppressWarnings("rawtypes")
         @CLIResolver
         static ParameterizedJob resolveForCLI(@Argument(required=true, metaVar="NAME", usage="Job name") String name) throws CmdLineException {
-            ParameterizedJob item = Jenkins.getInstance().getItemByFullName(name, ParameterizedJob.class);
+            ParameterizedJob item = Jenkins.get().getItemByFullName(name, ParameterizedJob.class);
             if (item == null) {
-                ParameterizedJob project = Items.findNearest(ParameterizedJob.class, name, Jenkins.getInstance());
+                ParameterizedJob project = Items.findNearest(ParameterizedJob.class, name, Jenkins.get());
                 throw new CmdLineException(null, project == null ?
                         hudson.model.Messages.AbstractItem_NoSuchJobExistsWithoutSuggestion(name) :
                         hudson.model.Messages.AbstractItem_NoSuchJobExists(name, project.getFullName()));
@@ -358,7 +358,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
          * @return by default, {@link Jenkins#getQuietPeriod}
          */
         default int getQuietPeriod() {
-            return Jenkins.getInstance().getQuietPeriod();
+            return Jenkins.get().getQuietPeriod();
         }
 
         /**
@@ -480,7 +480,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
             }
             setDisabled(b);
             if (b) {
-                Jenkins.getInstance().getQueue().cancel(this);
+                Jenkins.get().getQueue().cancel(this);
             }
             save();
             ItemListener.fireOnUpdated(this);

--- a/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
+++ b/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
@@ -52,11 +52,11 @@ import org.kohsuke.stapler.QueryParameter;
 public abstract class ProjectNamingStrategy implements Describable<ProjectNamingStrategy>, ExtensionPoint {
 
     public ProjectNamingStrategyDescriptor getDescriptor() {
-        return (ProjectNamingStrategyDescriptor) Jenkins.getInstance().getDescriptor(getClass());
+        return (ProjectNamingStrategyDescriptor) Jenkins.get().getDescriptor(getClass());
     }
 
     public static DescriptorExtensionList<ProjectNamingStrategy, ProjectNamingStrategyDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(ProjectNamingStrategy.class);
+        return Jenkins.get().getDescriptorList(ProjectNamingStrategy.class);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/RunIdMigrator.java
+++ b/core/src/main/java/jenkins/model/RunIdMigrator.java
@@ -423,12 +423,12 @@ public final class RunIdMigrator {
 
         @Override
         public Object getTarget() {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             return this;
         }
 
         public String getCommand() {
-            return RunIdMigrator.getUnmigrationCommandLine(Jenkins.getInstance().getRootDir());
+            return RunIdMigrator.getUnmigrationCommandLine(Jenkins.get().getRootDir());
         }
     }
 }

--- a/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
+++ b/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
@@ -55,7 +55,7 @@ public class UnlabeledLoadStatistics extends LoadStatistics {
     @Override
     public int computeIdleExecutors() {
         int r=0;
-        for (Computer c : Jenkins.getInstance().getComputers()) {
+        for (Computer c : Jenkins.get().getComputers()) {
             Node node = c.getNode();
             if (node != null && node.getMode() == Mode.NORMAL && (c.isOnline() || c.isConnecting()) && c.isAcceptingTasks()) {
                 r += c.countIdle();
@@ -67,7 +67,7 @@ public class UnlabeledLoadStatistics extends LoadStatistics {
     @Override
     public int computeTotalExecutors() {
         int r=0;
-        for (Computer c : Jenkins.getInstance().getComputers()) {
+        for (Computer c : Jenkins.get().getComputers()) {
             Node node = c.getNode();
             if (node != null && node.getMode() == Mode.NORMAL && c.isOnline()) {
                 r += c.countExecutors();
@@ -78,7 +78,7 @@ public class UnlabeledLoadStatistics extends LoadStatistics {
 
     @Override
     public int computeQueueLength() {
-        return Jenkins.getInstance().getQueue().strictCountBuildableItemsFor(null);
+        return Jenkins.get().getQueue().strictCountBuildableItemsFor(null);
     }
 
     @Override

--- a/core/src/main/java/jenkins/mvn/GlobalSettingsProviderDescriptor.java
+++ b/core/src/main/java/jenkins/mvn/GlobalSettingsProviderDescriptor.java
@@ -17,6 +17,6 @@ public abstract class GlobalSettingsProviderDescriptor extends Descriptor<Global
 
     @WithBridgeMethods(List.class)
     public static DescriptorExtensionList<GlobalSettingsProvider,GlobalSettingsProviderDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(GlobalSettingsProvider.class);
+        return Jenkins.get().getDescriptorList(GlobalSettingsProvider.class);
     }
 }

--- a/core/src/main/java/jenkins/mvn/SettingsProviderDescriptor.java
+++ b/core/src/main/java/jenkins/mvn/SettingsProviderDescriptor.java
@@ -17,6 +17,6 @@ public abstract class SettingsProviderDescriptor extends Descriptor<SettingsProv
 
     @WithBridgeMethods(List.class)
     public static DescriptorExtensionList<SettingsProvider,SettingsProviderDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(SettingsProvider.class);
+        return Jenkins.get().getDescriptorList(SettingsProvider.class);
     }
 }

--- a/core/src/main/java/jenkins/scm/SCMCheckoutStrategyDescriptor.java
+++ b/core/src/main/java/jenkins/scm/SCMCheckoutStrategyDescriptor.java
@@ -30,7 +30,7 @@ public abstract class SCMCheckoutStrategyDescriptor extends Descriptor<SCMChecko
      * Returns all the registered {@link SCMCheckoutStrategy}s.
      */
     public static DescriptorExtensionList<SCMCheckoutStrategy,SCMCheckoutStrategyDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(SCMCheckoutStrategy.class);
+        return Jenkins.get().getDescriptorList(SCMCheckoutStrategy.class);
     }
     
     public static List<SCMCheckoutStrategyDescriptor> _for(AbstractProject p) {

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -181,7 +181,7 @@ public class ApiTokenProperty extends UserProperty {
         }
 
         String p = apiToken.getPlainText();
-        if (p.equals(Util.getDigestOf(Jenkins.getInstance().getSecretKey()+":"+user.getId()))) {
+        if (p.equals(Util.getDigestOf(Jenkins.get().getSecretKey()+":"+user.getId()))) {
             // if the current token is the initial value created by pre SECURITY-49 Jenkins, we can't use that.
             // force using the newer value
             apiToken = Secret.fromString(p=API_KEY_SEED.mac(user.getId()));

--- a/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
@@ -53,7 +53,7 @@ public class BasicHeaderRealPasswordAuthenticator extends BasicHeaderAuthenticat
         authRequest.setDetails(authenticationDetailsSource.buildDetails(req));
 
         try {
-            Authentication a = Jenkins.getInstance().getSecurityRealm().getSecurityComponents().manager.authenticate(authRequest);
+            Authentication a = Jenkins.get().getSecurityRealm().getSecurityComponents().manager.authenticate(authRequest);
             // Authentication success
             LOGGER.log(FINER, "Authentication success: {0}", a);
             return a;

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -64,7 +64,7 @@ public abstract class ConfidentialStore {
     public static @Nonnull ConfidentialStore get() {
         if (TEST!=null) return TEST.get();
 
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         Lookup lookup = j.lookup;
         ConfidentialStore cs = lookup.get(ConfidentialStore.class);
         if (cs==null) {

--- a/core/src/main/java/jenkins/security/CustomClassFilter.java
+++ b/core/src/main/java/jenkins/security/CustomClassFilter.java
@@ -154,7 +154,7 @@ public interface CustomClassFilter extends ExtensionPoint {
         public static void load() throws IOException {
             Map<String, Boolean> overrides = ExtensionList.lookup(CustomClassFilter.class).get(Contributed.class).overrides;
             overrides.clear();
-            Enumeration<URL> resources = Jenkins.getInstance().getPluginManager().uberClassLoader.getResources("META-INF/hudson.remoting.ClassFilter");
+            Enumeration<URL> resources = Jenkins.get().getPluginManager().uberClassLoader.getResources("META-INF/hudson.remoting.ClassFilter");
             while (resources.hasMoreElements()) {
                 try (InputStream is = resources.nextElement().openStream()) {
                     for (String entry : IOUtils.readLines(is, StandardCharsets.UTF_8)) {

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -48,7 +48,7 @@ public class DefaultConfidentialStore extends ConfidentialStore {
     private final SecretKey masterKey;
 
     public DefaultConfidentialStore() throws IOException, InterruptedException {
-        this(new File(Jenkins.getInstance().getRootDir(),"secrets"));
+        this(new File(Jenkins.get().getRootDir(),"secrets"));
     }
 
     public DefaultConfidentialStore(File rootDir) throws IOException, InterruptedException {

--- a/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
+++ b/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
@@ -122,7 +122,7 @@ public class LastGrantedAuthoritiesProperty extends UserProperty {
             // just by failing to login. See ApiTokenFilter that does the following, which seems better:
             /*
                 try {
-                    Jenkins.getInstance().getSecurityRealm().loadUserByUsername(username);
+                    Jenkins.get().getSecurityRealm().loadUserByUsername(username);
                 } catch (UserMayOrMayNotExistException x) {
                     // OK, give them the benefit of the doubt.
                 } catch (UsernameNotFoundException x) {

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorDescriptor.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorDescriptor.java
@@ -14,6 +14,6 @@ public abstract class QueueItemAuthenticatorDescriptor extends Descriptor<QueueI
     // nothing defined here yet
 
     public static DescriptorExtensionList<QueueItemAuthenticator,QueueItemAuthenticatorDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(QueueItemAuthenticator.class);
+        return Jenkins.get().getDescriptorList(QueueItemAuthenticator.class);
     }
 }

--- a/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
+++ b/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
@@ -59,7 +59,7 @@ public class RekeySecretAdminMonitor extends AsynchronousAdministrativeMonitor {
         // this computation needs to be done and the value be captured,
         // since $JENKINS_HOME/config.xml can be saved later before the user has
         // actually rewritten XML files.
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         if (j.isUpgradedFromBefore(new VersionNumber("1.496.*"))
         &&  new FileBoolean(new File(j.getRootDir(),"secret.key.not-so-secret")).isOff())
             needed.on();
@@ -141,7 +141,7 @@ public class RekeySecretAdminMonitor extends AsynchronousAdministrativeMonitor {
         try {
             PrintStream log = listener.getLogger();
             log.println("Started re-keying " + new Date());
-            int count = rewriter.rewriteRecursive(Jenkins.getInstance().getRootDir(), listener);
+            int count = rewriter.rewriteRecursive(Jenkins.get().getRootDir(), listener);
             log.printf("Completed re-keying %d files on %s\n",count,new Date());
             new RekeySecretAdminMonitor().done.on();
             LOGGER.info("Secret re-keying completed");

--- a/core/src/main/java/jenkins/security/SecureRequester.java
+++ b/core/src/main/java/jenkins/security/SecureRequester.java
@@ -43,7 +43,7 @@ public interface SecureRequester extends ExtensionPoint {
         }
 
         @Override public boolean permit(StaplerRequest req, Object bean) {
-            return INSECURE || !Jenkins.getInstance().isUseSecurity();
+            return INSECURE || !Jenkins.get().isUseSecurity();
         }
 
     }

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
@@ -109,7 +109,7 @@ public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
 
             String pluginName = warning.component;
 
-            PluginWrapper plugin = Jenkins.getInstance().getPluginManager().getPlugin(pluginName);
+            PluginWrapper plugin = Jenkins.get().getPluginManager().getPlugin(pluginName);
 
             if (!activePluginWarningsByPlugin.containsKey(plugin)) {
                 activePluginWarningsByPlugin.put(plugin, new ArrayList<>());

--- a/core/src/main/java/jenkins/security/UserDetailsCache.java
+++ b/core/src/main/java/jenkins/security/UserDetailsCache.java
@@ -168,7 +168,7 @@ public final class UserDetailsCache {
         @Override
         public UserDetails call() throws Exception {
             try {
-                Jenkins jenkins = Jenkins.getInstance();
+                Jenkins jenkins = Jenkins.get();
                 UserDetails userDetails = jenkins.getSecurityRealm().loadUserByUsername(idOrFullName);
                 if (userDetails == null) {
                     existenceCache.put(this.idOrFullName, Boolean.FALSE);

--- a/core/src/main/java/jenkins/security/s2m/CallableRejectionConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableRejectionConfig.java
@@ -41,7 +41,7 @@ public class CallableRejectionConfig extends ConfigFile<Class,Set<Class>> {
             line = line.trim();
             if (whitelist.contains(line))   return null;    // already whitelisted
 
-            return Jenkins.getInstance().pluginManager.uberClassLoader.loadClass(line);
+            return Jenkins.get().pluginManager.uberClassLoader.loadClass(line);
         } catch (ClassNotFoundException e) {
             // no longer present in the system?
             return null;

--- a/core/src/main/java/jenkins/security/s2m/CallableWhitelist.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableWhitelist.java
@@ -43,6 +43,6 @@ public abstract class CallableWhitelist implements ExtensionPoint {
     public abstract boolean isWhitelisted(RoleSensitive subject, Collection<Role> expected, Object context);
 
     public static ExtensionList<CallableWhitelist> all() {
-        return Jenkins.getInstance().getExtensionList(CallableWhitelist.class);
+        return Jenkins.get().getExtensionList(CallableWhitelist.class);
     }
 }

--- a/core/src/main/java/jenkins/security/s2m/ConfigFile.java
+++ b/core/src/main/java/jenkins/security/s2m/ConfigFile.java
@@ -88,7 +88,7 @@ abstract class ConfigFile<T,COL extends Collection<T>> extends TextFile {
     protected abstract T parse(String line);
 
     public synchronized void set(String newContent) throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         write(newContent);
         load2();

--- a/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
@@ -42,7 +42,7 @@ class FilePathRuleConfig extends ConfigDirectory<FilePathRule,List<FilePathRule>
         line = line.replace("<BUILDDIR>","<JOBDIR>/builds/<BUILDID>");
         line = line.replace("<BUILDID>","(?:[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9]|[0-9]+)");
         line = line.replace("<JOBDIR>","<JENKINS_HOME>/jobs/.+");
-        line = line.replace("<JENKINS_HOME>","\\Q"+Jenkins.getInstance().getRootDir().getPath()+"\\E");
+        line = line.replace("<JENKINS_HOME>","\\Q"+Jenkins.get().getRootDir().getPath()+"\\E");
 
         // config file is always /-separated even on Windows, so bring it back to \-separation.
         // This is done in the context of regex, so it has to be \\, which means in the source code it is \\\\

--- a/core/src/main/java/jenkins/security/s2m/RejectedCallable.java
+++ b/core/src/main/java/jenkins/security/s2m/RejectedCallable.java
@@ -17,6 +17,6 @@ public /*for Jelly*/ class RejectedCallable {
 
     public @CheckForNull
     PluginWrapper getPlugin() {
-        return Jenkins.getInstance().pluginManager.whichPlugin(clazz);
+        return Jenkins.get().pluginManager.whichPlugin(clazz);
     }
 }

--- a/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
@@ -25,34 +25,16 @@
 package jenkins.tasks;
 
 import hudson.AbortException;
-import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.BuildListener;
-import hudson.model.Computer;
-import hudson.model.Executor;
-import hudson.model.InvisibleAction;
-import hudson.model.Job;
-import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.tasks.BuildStep;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.BuildStepMonitor;
-import hudson.tasks.Builder;
-import hudson.tasks.Publisher;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import javax.annotation.Nonnull;
+import hudson.model.*;
+import hudson.tasks.*;
 import jenkins.model.DependencyDeclarer;
 import jenkins.model.RunAction2;
-import jenkins.model.TransientActionFactory;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Collection;
 
 /**
  * A build step (like a {@link Builder} or {@link Publisher}) which may be called at an arbitrary time during a build (or multiple times), run, and be done.
@@ -99,34 +81,6 @@ public interface SimpleBuildStep extends BuildStep {
          * if you need to know the {@link Job}, implement {@link RunAction2} and use {@link Run#getParent}
          */
         Collection<? extends Action> getProjectActions();
-
-    }
-
-    @SuppressWarnings("rawtypes")
-    @Restricted(NoExternalUse.class)
-    @Extension
-    final class LastBuildActionFactory extends TransientActionFactory<Job> {
-
-        @Override
-        public Class<Job> type() {
-            return Job.class;
-        }
-
-        @Nonnull
-        @Override
-        public Collection<? extends Action> createFor(@Nonnull Job j) {
-            List<Action> actions = new LinkedList<>();
-            Run r = j.getLastSuccessfulBuild();
-            if (r != null) {
-                for (LastBuildAction a : r.getActions(LastBuildAction.class)) {
-                    actions.addAll(a.getProjectActions());
-                }
-            }
-            // TODO should there be an option to check lastCompletedBuild even if it failed?
-            // Not useful for, say, TestResultAction, since if you have a build that fails before recording test
-            // results, the job would then have no TestResultProjectAction.
-            return actions;
-        }
 
     }
 

--- a/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
+++ b/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
@@ -82,7 +82,7 @@ public class GlobalToolConfiguration extends ManagementLink {
     }
 
     private boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException, IOException {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         j.checkPermission(Jenkins.ADMINISTER);
 
         boolean result = true;

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -130,7 +130,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     }
 
     private boolean shouldTrigger(Run upstreamBuild, TaskListener listener) {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         if (job == null) {
             return false;
         }
@@ -220,7 +220,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
             while(tokens.hasMoreTokens()) {
                 String projectName = tokens.nextToken().trim();
                 if (StringUtils.isNotBlank(projectName)) {
-                    Job item = Jenkins.getInstance().getItem(projectName, project, Job.class);
+                    Job item = Jenkins.get().getItem(projectName, project, Job.class);
                     if (item == null) {
                         Job nearest = Items.findNearest(Job.class, projectName, project.getParent());
                         String alternative = nearest != null ? nearest.getRelativeNameFrom(project) : "?";
@@ -253,7 +253,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
         private Map<Job,Collection<ReverseBuildTrigger>> calculateCache() {
             try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 final Map<Job, Collection<ReverseBuildTrigger>> result = new WeakHashMap<>();
-                for (Job<?, ?> downstream : Jenkins.getInstance().allItems(Job.class)) {
+                for (Job<?, ?> downstream : Jenkins.get().allItems(Job.class)) {
                     ReverseBuildTrigger trigger =
                             ParameterizedJobMixIn.getTrigger(downstream, ReverseBuildTrigger.class);
                     if (trigger == null) {
@@ -309,7 +309,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
         @Override
         public void onLocationChanged(Item item, final String oldFullName, final String newFullName) {
             try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
-                for (Job<?, ?> p : Jenkins.getInstance().allItems(Job.class)) {
+                for (Job<?, ?> p : Jenkins.get().allItems(Job.class)) {
                     ReverseBuildTrigger t = ParameterizedJobMixIn.getTrigger(p, ReverseBuildTrigger.class);
                     if (t != null) {
                         String revised =

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -244,7 +244,7 @@ public class JSONSignatureValidator {
         // if we trust default root CAs, we end up trusting anyone who has a valid certificate,
         // which isn't useful at all
         Set<TrustAnchor> anchors = new HashSet<>(); // CertificateUtil.getDefaultRootCAs();
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         for (String cert : j.servletContext.getResourcePaths("/WEB-INF/update-center-rootCAs")) {
             if (cert.endsWith("/") || cert.endsWith(".txt"))  {
                 continue;       // skip directories also any text files that are meant to be documentation

--- a/core/src/main/java/jenkins/util/io/FileBoolean.java
+++ b/core/src/main/java/jenkins/util/io/FileBoolean.java
@@ -29,7 +29,7 @@ public class FileBoolean {
     }
 
     public FileBoolean(Class owner, String name) {
-        this(new File(Jenkins.getInstance().getRootDir(),owner.getName().replace('$','.')+'/'+name));
+        this(new File(Jenkins.get().getRootDir(),owner.getName().replace('$','.')+'/'+name));
     }
 
     /**

--- a/core/src/main/java/jenkins/widgets/BuildTimeTrend.java
+++ b/core/src/main/java/jenkins/widgets/BuildTimeTrend.java
@@ -53,7 +53,7 @@ public class BuildTimeTrend extends RunListProgressiveRendering {
                 if (ns != null && !ns.isEmpty()) {
                     element.put("builtOnStr", ns);
                 }
-            } else if (n != Jenkins.getInstance()) {
+            } else if (n != Jenkins.get()) {
                 element.put("builtOn", n.getNodeName());
                 element.put("builtOnStr", n.getDisplayName());
             } else {

--- a/core/src/main/resources/META-INF/upgrade/ExtensionList.hint
+++ b/core/src/main/resources/META-INF/upgrade/ExtensionList.hint
@@ -1,1 +1,1 @@
-jenkins.model.Jenkins.getInstance().getExtensionList($c) :: $c instanceof java.lang.Class => hudson.ExtensionList.lookup($c);;
+jenkins.model.Jenkins.get().getExtensionList($c) :: $c instanceof java.lang.Class => hudson.ExtensionList.lookup($c);;

--- a/core/src/main/resources/META-INF/upgrade/Jenkins.hint
+++ b/core/src/main/resources/META-INF/upgrade/Jenkins.hint
@@ -1,2 +1,2 @@
-jenkins.model.Jenkins.getInstance() => jenkins.model.Jenkins.get();;
+jenkins.model.Jenkins.get() => jenkins.model.Jenkins.get();;
 jenkins.model.Jenkins.getActiveInstance() => jenkins.model.Jenkins.get();;

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -266,7 +266,7 @@ public class FunctionsTest {
     private Jenkins createMockJenkins() {
         mockStatic(Jenkins.class);
         Jenkins j = mock(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(j);
+        when(Jenkins.get()).thenReturn(j);
         return j;
     }
     

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -54,7 +54,7 @@ public class ListJobsCommandTest {
 
         jenkins = mock(Jenkins.class);
         mockStatic(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
         when(Jenkins.getActiveInstance()).thenReturn(jenkins);
         command = mock(ListJobsCommand.class, Mockito.CALLS_REAL_METHODS);
         command.stdout = new PrintStream(stdout);

--- a/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
+++ b/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
@@ -83,7 +83,7 @@ public class ViewOptionHandlerTest {
         when(outer.getView("nested")).thenReturn(nested);
 
         PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
         PowerMockito.when(Jenkins.getActiveInstance()).thenReturn(jenkins);
         when(jenkins.getView("outer")).thenReturn(outer);
         when(jenkins.getDisplayName()).thenReturn("Jenkins");

--- a/core/src/test/java/hudson/slaves/DelegatingComputerLauncherTest.java
+++ b/core/src/test/java/hudson/slaves/DelegatingComputerLauncherTest.java
@@ -53,7 +53,7 @@ public class DelegatingComputerLauncherTest {
     public void testRecursionAvoidance() {
         PowerMockito.mockStatic(Jenkins.class);
         Jenkins mockJenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(mockJenkins);
+        PowerMockito.when(Jenkins.get()).thenReturn(mockJenkins);
 
         DescriptorExtensionList<ComputerLauncher, Descriptor<ComputerLauncher>> mockList =
                 mock(DescriptorExtensionList.class);

--- a/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
+++ b/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
@@ -48,7 +48,7 @@ public class CoreEnvironmentContributorTest {
     public void buildEnvironmentForJobShouldntUseCurrentComputer() throws IOException, InterruptedException {
         PowerMockito.mockStatic(Computer.class);
         PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
         when(jenkins.getRootDir()).thenReturn(new File("."));
         
         EnvVars env = new EnvVars();

--- a/core/src/test/java/jenkins/model/NewViewLinkTest.java
+++ b/core/src/test/java/jenkins/model/NewViewLinkTest.java
@@ -37,7 +37,7 @@ public class NewViewLinkTest {
     @Before
     public void initTests() throws Exception {
     PowerMockito.mockStatic(Jenkins.class);
-    PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+    PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
     PowerMockito.when(jenkins.getRootUrl()).thenReturn(rootUrl);
     newViewLink = new NewViewLink();
     }

--- a/test/src/test/java/hudson/AbstractItemSecurity1114Test.java
+++ b/test/src/test/java/hudson/AbstractItemSecurity1114Test.java
@@ -71,7 +71,7 @@ public class AbstractItemSecurity1114Test {
         public Item getDynamic(String name) {
             Item item;
             try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
-                 item = Jenkins.getInstance().getItemByFullName(name);
+                 item = Jenkins.get().getItemByFullName(name);
             }
             return item;
         }

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -96,7 +96,7 @@ public class ExtensionListTest {
 
     public static abstract class Fish implements Describable<Fish> {
         public Descriptor<Fish> getDescriptor() {
-            return Jenkins.getInstance().getDescriptor(getClass());
+            return Jenkins.get().getDescriptor(getClass());
         }
     }
 

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -253,7 +253,7 @@ public class PluginManagerTest {
     // org.jenkinsci.plugins.dependencytest.depender:
     //   public class Depender {
     //     public static String getValue() {
-    //       if (Jenkins.getInstance().getPlugin("dependee") != null) {
+    //       if (Jenkins.get().getPlugin("dependee") != null) {
     //         return Dependee.getValue();
     //       }
     //       return "depender";

--- a/test/src/test/java/hudson/PluginTest.java
+++ b/test/src/test/java/hudson/PluginTest.java
@@ -70,7 +70,7 @@ public class PluginTest {
     @Issue("SECURITY-925")
     public void preventTimestamp2_toBeServed() throws Exception {
         // impossible to use installDetachedPlugin("credentials") since we want to have it exploded like with WAR
-        Jenkins.getInstance().getUpdateCenter().getSites().get(0).updateDirectlyNow(false);
+        Jenkins.get().getUpdateCenter().getSites().get(0).updateDirectlyNow(false);
         List<Future<UpdateCenter.UpdateCenterJob>> pluginInstalled = r.jenkins.pluginManager.install(Arrays.asList("credentials"), true);
 
         for (Future<UpdateCenter.UpdateCenterJob> job : pluginInstalled) {

--- a/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
@@ -169,7 +169,7 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).isBuilding(), equalTo(false));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).isInQueue(), equalTo(true));
 
-        Jenkins.getInstance().getQueue().cancel(project);
+        Jenkins.get().getQueue().cancel(project);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(0));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).isBuilding(), equalTo(false));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).isInQueue(), equalTo(false));

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -355,9 +355,9 @@ public class AbstractProjectTest {
         j.createFreeStyleProject("j1");
         assertEquals("", deleteRedirectTarget("job/j1"));
         j.createFreeStyleProject("j2");
-        Jenkins.getInstance().addView(new AllView("v1"));
+        Jenkins.get().addView(new AllView("v1"));
         assertEquals("view/v1/", deleteRedirectTarget("view/v1/job/j2"));
-        MockFolder d = Jenkins.getInstance().createProject(MockFolder.class, "d");
+        MockFolder d = Jenkins.get().createProject(MockFolder.class, "d");
         d.addView(new AllView("v2"));
         for (String n : new String[] {"j3", "j4", "j5"}) {
             d.createProject(FreeStyleProject.class, n);

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -56,12 +56,12 @@ public class ComputerTest {
 
     @Test
     public void discardLogsAfterDeletion() throws Exception {
-        DumbSlave delete = j.createOnlineSlave(Jenkins.getInstance().getLabelAtom("delete"));
-        DumbSlave keep = j.createOnlineSlave(Jenkins.getInstance().getLabelAtom("keep"));
+        DumbSlave delete = j.createOnlineSlave(Jenkins.get().getLabelAtom("delete"));
+        DumbSlave keep = j.createOnlineSlave(Jenkins.get().getLabelAtom("keep"));
         File logFile = delete.toComputer().getLogFile();
         assertTrue(logFile.exists());
 
-        Jenkins.getInstance().removeNode(delete);
+        Jenkins.get().removeNode(delete);
 
         assertFalse("Slave log should be deleted", logFile.exists());
         assertFalse("Slave log directory should be deleted", logFile.getParentFile().exists());

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -99,7 +99,7 @@ public class DescriptorTest {
             return true;
         }
         @Override public Descriptor<Builder> getDescriptor() {
-            return (Descriptor<Builder>) Jenkins.getInstance().getDescriptorByName(id);
+            return (Descriptor<Builder>) Jenkins.get().getDescriptorByName(id);
         }
     }
     private static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
@@ -172,7 +172,7 @@ public class DescriptorTest {
             return id;
         }
         @Override public Descriptor<D3> getDescriptor() {
-            return Jenkins.getInstance().getDescriptorByName(id);
+            return Jenkins.get().getDescriptorByName(id);
         }
     }
     public static class D3D extends Descriptor<D3> {
@@ -209,7 +209,7 @@ public class DescriptorTest {
         try {
             rule.executeOnServer(new Callable<Void>() {
                 @Override public Void call() throws Exception {
-                    fe.generateResponse(Stapler.getCurrentRequest(), Stapler.getCurrentResponse(), Jenkins.getInstance());
+                    fe.generateResponse(Stapler.getCurrentRequest(), Stapler.getCurrentResponse(), Jenkins.get());
                     return null;
                 }
             });

--- a/test/src/test/java/hudson/model/DisplayNameTest.java
+++ b/test/src/test/java/hudson/model/DisplayNameTest.java
@@ -74,7 +74,7 @@ public class DisplayNameTest {
         FreeStyleProject project = j.createFreeStyleProject(projectName);
         assertEquals(projectName, project.getDisplayName());
 
-        AbstractProject newProject = Jenkins.getInstance().copy((AbstractProject)project, newProjectName);
+        AbstractProject newProject = Jenkins.get().copy((AbstractProject)project, newProjectName);
         assertEquals(newProjectName, newProject.getName());
         assertEquals(newProjectName, newProject.getDisplayName());
     }
@@ -89,7 +89,7 @@ public class DisplayNameTest {
         project.setDisplayName(oldDisplayName);
         assertEquals(oldDisplayName, project.getDisplayName());
 
-        AbstractProject newProject = Jenkins.getInstance().copy((AbstractProject)project, newProjectName);
+        AbstractProject newProject = Jenkins.get().copy((AbstractProject)project, newProjectName);
         assertEquals(newProjectName, newProject.getName());
         assertEquals(newProjectName, newProject.getDisplayName());
         

--- a/test/src/test/java/hudson/model/GetEnvironmentOutsideBuildTest.java
+++ b/test/src/test/java/hudson/model/GetEnvironmentOutsideBuildTest.java
@@ -40,7 +40,7 @@ public class GetEnvironmentOutsideBuildTest extends HudsonTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        this.oldExecNum = Jenkins.getInstance().getNumExecutors();
+        this.oldExecNum = Jenkins.get().getNumExecutors();
     }
 
     public void tearDown() throws Exception {
@@ -49,8 +49,8 @@ public class GetEnvironmentOutsideBuildTest extends HudsonTestCase {
     }
 
     private void restoreOldNumExecutors() throws IOException {
-        Jenkins.getInstance().setNumExecutors(this.oldExecNum);
-        assertNotNull(Jenkins.getInstance().toComputer());
+        Jenkins.get().setNumExecutors(this.oldExecNum);
+        assertNotNull(Jenkins.get().toComputer());
     }
 
     private MavenModuleSet createSimpleMavenProject() throws Exception {
@@ -64,8 +64,8 @@ public class GetEnvironmentOutsideBuildTest extends HudsonTestCase {
     }
 
     private void whenJenkinsMasterHasNoExecutors() throws IOException {
-        Jenkins.getInstance().setNumExecutors(0);
-        assertNull(Jenkins.getInstance().toComputer());
+        Jenkins.get().setNumExecutors(0);
+        assertNull(Jenkins.get().toComputer());
     }
 
     public void testMaven() throws Exception {

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -502,7 +502,7 @@ public class NodeTest {
         public Collection<LabelAtom> findLabels(Node node) {
             List<LabelAtom> atoms = new ArrayList<LabelAtom>();
             if(addDynamicLabel){
-                atoms.add(Jenkins.getInstance().getLabelAtom("dynamicLabel"));
+                atoms.add(Jenkins.get().getLabelAtom("dynamicLabel"));
             }
             return atoms;
 

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -373,7 +373,7 @@ public class ProjectTest {
         FreeStyleProject downstream = j.createFreeStyleProject("project-downstream");
         downstream.getBuildersList().add(Functions.isWindows() ? new BatchFile("ping -n 10 127.0.0.1 >nul") : new Shell("sleep 10"));
         p.getPublishersList().add(new BuildTrigger(Collections.singleton(downstream), Result.SUCCESS));
-        Jenkins.getInstance().rebuildDependencyGraph();
+        Jenkins.get().rebuildDependencyGraph();
         p.setBlockBuildWhenDownstreamBuilding(true);
         QueueTaskFuture<FreeStyleBuild> b2 = waitForStart(downstream);
         assertInstanceOf("Build can not start because build of downstream project has not finished.", p.getCauseOfBlockage(), BecauseOfDownstreamBuildInProgress.class);
@@ -956,7 +956,7 @@ public class ProjectTest {
 
         @Override
         public Task getOwnerTask() {
-            return (Task) Jenkins.getInstance().getItem(projectName);
+            return (Task) Jenkins.get().getItem(projectName);
         }
 
         @Override

--- a/test/src/test/java/hudson/model/ViewJobTest.java
+++ b/test/src/test/java/hudson/model/ViewJobTest.java
@@ -64,7 +64,7 @@ public class ViewJobTest {
         }
 
         @Override public TopLevelItemDescriptor getDescriptor() {
-            return Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
+            return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
         }
 
         @TestExtension public static final class DescriptorImpl extends TopLevelItemDescriptor {

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -391,7 +391,7 @@ public class SearchTest {
         j.jenkins.addView(new ListView("foo", j.jenkins));
 
         // SYSTEM can see all the views
-        assertEquals("two views exist", 2, Jenkins.getInstance().getViews().size());
+        assertEquals("two views exist", 2, Jenkins.get().getViews().size());
         List<SearchItem> results = new ArrayList<>();
         j.jenkins.getSearchIndex().suggest("foo", results);
         assertEquals("nonempty results list", 1, results.size());
@@ -402,7 +402,7 @@ public class SearchTest {
         ACL.impersonate(User.get("alice").impersonate(), new Runnable() {
             @Override
             public void run() {
-                assertEquals("no visible views", 0, Jenkins.getInstance().getViews().size());
+                assertEquals("no visible views", 0, Jenkins.get().getViews().size());
 
                 List<SearchItem> results = new ArrayList<>();
                 j.jenkins.getSearchIndex().suggest("foo", results);

--- a/test/src/test/java/hudson/tasks/FingerprinterTest.java
+++ b/test/src/test/java/hudson/tasks/FingerprinterTest.java
@@ -187,7 +187,7 @@ public class FingerprinterTest {
 
         upstreamBuild.delete();
 
-        Jenkins.getInstance().rebuildDependencyGraph();
+        Jenkins.get().rebuildDependencyGraph();
 
         List<AbstractProject> upstreamProjects = downstream.getUpstreamProjects();
         List<AbstractProject> downstreamProjects = upstream.getDownstreamProjects();
@@ -202,7 +202,7 @@ public class FingerprinterTest {
         j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
         
-        Jenkins.getInstance().rebuildDependencyGraph();
+        Jenkins.get().rebuildDependencyGraph();
 
         List<AbstractProject> upstreamProjects = p.getUpstreamProjects();
         List<AbstractProject> downstreamProjects = p.getDownstreamProjects();

--- a/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
+++ b/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
@@ -115,7 +115,7 @@ public class ToolLocationNodePropertyTest {
     public void maven() throws Exception {
         MavenInstallation maven = ToolInstallations.configureDefaultMaven();
         String mavenPath = maven.getHome();
-        Jenkins.getInstance().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(new MavenInstallation("maven", "THIS IS WRONG", j.NO_PROPERTIES));
+        Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(new MavenInstallation("maven", "THIS IS WRONG", j.NO_PROPERTIES));
 
         project.getBuildersList().add(new Maven("--version", "maven"));
         configureDumpEnvBuilder();
@@ -142,7 +142,7 @@ public class ToolLocationNodePropertyTest {
     public void ant() throws Exception {
         Ant.AntInstallation ant = ToolInstallations.configureDefaultAnt(tmp);
         String antPath = ant.getHome();
-        Jenkins.getInstance().getDescriptorByType(Ant.DescriptorImpl.class).setInstallations(new AntInstallation("ant", "THIS IS WRONG"));
+        Jenkins.get().getDescriptorByType(Ant.DescriptorImpl.class).setInstallations(new AntInstallation("ant", "THIS IS WRONG"));
 
         project.setScm(new SingleFileSCM("build.xml", "<project name='foo'/>"));
         project.getBuildersList().add(new Ant("-version", "ant", null,null,null));
@@ -164,7 +164,7 @@ public class ToolLocationNodePropertyTest {
     public void nativeMaven() throws Exception {
         MavenInstallation maven = ToolInstallations.configureDefaultMaven();
         String mavenPath = maven.getHome();
-        Jenkins.getInstance().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(new MavenInstallation("maven", "THIS IS WRONG", j.NO_PROPERTIES));
+        Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(new MavenInstallation("maven", "THIS IS WRONG", j.NO_PROPERTIES));
 
         MavenModuleSet project = j.jenkins.createProject(MavenModuleSet.class, "p");
         project.setScm(new ExtractResourceSCM(getClass().getResource(

--- a/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -163,7 +163,7 @@ public class RobustReflectionConverterTest {
                 // unfortunately, default newInstance bypasses newInstances for members.
                 formData = formData.getJSONObject("keywordProperty");
                 @SuppressWarnings("unchecked")
-                Descriptor<AcceptOnlySpecificKeyword> d = Jenkins.getInstance().getDescriptor(AcceptOnlySpecificKeyword.class);
+                Descriptor<AcceptOnlySpecificKeyword> d = Jenkins.get().getDescriptor(AcceptOnlySpecificKeyword.class);
                 return new KeywordProperty(
                         d.newInstance(req, formData.getJSONObject("nonCriticalField")),
                         d.newInstance(req, formData.getJSONObject("criticalField"))

--- a/test/src/test/java/jenkins/bugs/Jenkins41511Test.java
+++ b/test/src/test/java/jenkins/bugs/Jenkins41511Test.java
@@ -21,7 +21,7 @@ public class Jenkins41511Test {
 
     @Test
     public void configRoundTrip() throws Exception {
-        Jenkins.getInstance().setSecurityRealm(new HudsonPrivateSecurityRealm(true, false, null));
+        Jenkins.get().setSecurityRealm(new HudsonPrivateSecurityRealm(true, false, null));
         j.submit(j.createWebClient().goTo("configureSecurity").getFormByName("config"));
     }
 }

--- a/test/src/test/java/jenkins/install/UpgradeWizardTest.java
+++ b/test/src/test/java/jenkins/install/UpgradeWizardTest.java
@@ -42,7 +42,7 @@ public class UpgradeWizardTest {
     private void setSetupWizard(SetupWizard wiz) throws Exception {
         Field f = Jenkins.class.getDeclaredField("setupWizard");
         f.setAccessible(true);
-        f.set(Jenkins.getInstance(), wiz);
+        f.set(Jenkins.get(), wiz);
     }
     
     @Before

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -136,7 +136,7 @@ public class JenkinsTest {
         FreeStyleProject p = j.createFreeStyleProject(jobName);
         p.setDisplayName("displayName");
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         assertTrue(jenkins.isDisplayNameUnique("displayName1", curJobName));
         assertTrue(jenkins.isDisplayNameUnique(jobName, curJobName));
     }
@@ -153,7 +153,7 @@ public class JenkinsTest {
         FreeStyleProject p = j.createFreeStyleProject(jobName);
         p.setDisplayName(displayName);
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         assertFalse(jenkins.isDisplayNameUnique(displayName, curJobName));
     }
     
@@ -165,7 +165,7 @@ public class JenkinsTest {
         FreeStyleProject curProject = j.createFreeStyleProject(curJobName);
         curProject.setDisplayName(displayName);
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         // should be true as we don't test against the current job
         assertTrue(jenkins.isDisplayNameUnique(displayName, curJobName));
     }
@@ -177,7 +177,7 @@ public class JenkinsTest {
         j.createFreeStyleProject(curJobName);
         j.createFreeStyleProject(jobName);
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         assertTrue(jenkins.isNameUnique("jobName1", curJobName));
     }
 
@@ -188,7 +188,7 @@ public class JenkinsTest {
         j.createFreeStyleProject(curJobName);
         j.createFreeStyleProject(jobName);
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         assertFalse(jenkins.isNameUnique(jobName, curJobName));
     }
 
@@ -199,7 +199,7 @@ public class JenkinsTest {
         j.createFreeStyleProject(curJobName);
         j.createFreeStyleProject(jobName);
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         // true because we don't test against the current job
         assertTrue(jenkins.isNameUnique(curJobName, curJobName));
     }
@@ -214,7 +214,7 @@ public class JenkinsTest {
         FreeStyleProject p = j.createFreeStyleProject(jobName);
         p.setDisplayName("displayName");
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         FormValidation v = jenkins.doCheckDisplayName("1displayName", curJobName);
         assertEquals(FormValidation.ok(), v);
     }
@@ -230,7 +230,7 @@ public class JenkinsTest {
         FreeStyleProject p = j.createFreeStyleProject(jobName);
         p.setDisplayName(displayName);
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         FormValidation v = jenkins.doCheckDisplayName(displayName, curJobName);
         assertEquals(FormValidation.Kind.WARNING, v.kind);
     }
@@ -246,7 +246,7 @@ public class JenkinsTest {
         FreeStyleProject p = j.createFreeStyleProject(jobName);
         p.setDisplayName(displayName);
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         FormValidation v = jenkins.doCheckDisplayName(jobName, curJobName);
         assertEquals(FormValidation.Kind.WARNING, v.kind);
     }
@@ -257,7 +257,7 @@ public class JenkinsTest {
             "", "Jenkins"    
         };
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         for (String viewName : viewNames) {
             FormValidation v = jenkins.doCheckViewName(viewName);
             assertEquals(FormValidation.Kind.OK, v.kind);
@@ -271,7 +271,7 @@ public class JenkinsTest {
             "Jenkins!", "Jenkins[]", "Jenkin<>s", "^Jenkins", ".."    
         };
         
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         
         for (String viewName : viewNames) {
             FormValidation v = jenkins.doCheckViewName(viewName);
@@ -381,7 +381,7 @@ public class JenkinsTest {
         }
 
         public HttpResponse doDynamic() {
-            assertTrue(Jenkins.getInstance().getAuthentication().getName().equals("anonymous"));
+            assertTrue(Jenkins.get().getAuthentication().getName().equals("anonymous"));
             count++;
             return HttpResponses.html("OK");
         }

--- a/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
+++ b/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
@@ -97,7 +97,7 @@ public class ApiTokenPropertyTest {
     public void security49Upgrade() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         User u = User.get("foo");
-        String historicalInitialValue = Util.getDigestOf(Jenkins.getInstance().getSecretKey() + ":" + u.getId());
+        String historicalInitialValue = Util.getDigestOf(Jenkins.get().getSecretKey() + ":" + u.getId());
 
         // we won't accept historically used initial value as it may be compromised
         ApiTokenProperty t = new ApiTokenProperty(historicalInitialValue);

--- a/test/src/test/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest.java
+++ b/test/src/test/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest.java
@@ -232,7 +232,7 @@ public class RedactSecretJsonInErrorMessageSanitizerHtmlTest {
         }
         
         public DescriptorImpl getDescriptor() {
-            return Jenkins.getInstance().getDescriptorByType(TestDescribable.DescriptorImpl.class);
+            return Jenkins.get().getDescriptorByType(TestDescribable.DescriptorImpl.class);
         }
         
         @TestExtension({
@@ -251,7 +251,7 @@ public class RedactSecretJsonInErrorMessageSanitizerHtmlTest {
         
         @RequirePOST
         public void doConfigSubmit(StaplerRequest req, StaplerResponse rsp) throws Exception {
-            Jenkins.getInstance().getDescriptorOrDie(TestDescribable.class).newInstance(req, req.getSubmittedForm());
+            Jenkins.get().getDescriptorOrDie(TestDescribable.class).newInstance(req, req.getSubmittedForm());
         }
         
         @Override

--- a/test/src/test/java/jenkins/security/Security380Test.java
+++ b/test/src/test/java/jenkins/security/Security380Test.java
@@ -24,15 +24,15 @@ public class Security380Test {
     public void testGetItemsWithoutAnonRead() throws Exception {
         FullControlOnceLoggedInAuthorizationStrategy strategy = new FullControlOnceLoggedInAuthorizationStrategy();
         strategy.setAllowAnonymousRead(false);
-        Jenkins.getInstance().setAuthorizationStrategy(strategy);
+        Jenkins.get().setAuthorizationStrategy(strategy);
 
-        Jenkins.getInstance().setSecurityRealm(j.createDummySecurityRealm());
+        Jenkins.get().setSecurityRealm(j.createDummySecurityRealm());
 
         j.createFreeStyleProject();
         ACL.impersonate(Jenkins.ANONYMOUS, new Runnable() {
             @Override
             public void run() {
-                Assert.assertEquals("no items", 0, Jenkins.getInstance().getItems().size());
+                Assert.assertEquals("no items", 0, Jenkins.get().getItems().size());
             }
         });
     }
@@ -42,15 +42,15 @@ public class Security380Test {
     public void testGetItems() throws Exception {
         FullControlOnceLoggedInAuthorizationStrategy strategy = new FullControlOnceLoggedInAuthorizationStrategy();
         strategy.setAllowAnonymousRead(true);
-        Jenkins.getInstance().setAuthorizationStrategy(strategy);
+        Jenkins.get().setAuthorizationStrategy(strategy);
 
-        Jenkins.getInstance().setSecurityRealm(j.createDummySecurityRealm());
+        Jenkins.get().setSecurityRealm(j.createDummySecurityRealm());
 
         j.createFreeStyleProject();
         ACL.impersonate(Jenkins.ANONYMOUS, new Runnable() {
             @Override
             public void run() {
-                Assert.assertEquals("one item", 1, Jenkins.getInstance().getItems().size());
+                Assert.assertEquals("one item", 1, Jenkins.get().getItems().size());
             }
         });
     }
@@ -60,9 +60,9 @@ public class Security380Test {
     public void testWithUnprotectedRootAction() throws Exception {
         FullControlOnceLoggedInAuthorizationStrategy strategy = new FullControlOnceLoggedInAuthorizationStrategy();
         strategy.setAllowAnonymousRead(false);
-        Jenkins.getInstance().setAuthorizationStrategy(strategy);
+        Jenkins.get().setAuthorizationStrategy(strategy);
 
-        Jenkins.getInstance().setSecurityRealm(j.createDummySecurityRealm());
+        Jenkins.get().setSecurityRealm(j.createDummySecurityRealm());
         j.createFreeStyleProject();
 
         JenkinsRule.WebClient wc = j.createWebClient();
@@ -90,7 +90,7 @@ public class Security380Test {
         }
 
         public HttpResponse doIndex() throws Exception {
-            return HttpResponses.plainText(Integer.toString(Jenkins.getInstance().getItems().size()));
+            return HttpResponses.plainText(Integer.toString(Jenkins.get().getItems().size()));
         }
     }
 }

--- a/test/src/test/java/jenkins/security/stapler/GetterMethodFilterTest.java
+++ b/test/src/test/java/jenkins/security/stapler/GetterMethodFilterTest.java
@@ -259,7 +259,7 @@ public class GetterMethodFilterTest extends StaplerAbstractTest {
     public static class TestWithReturnCoreObject extends AbstractUnprotectedRootAction {
         public View.People getPeople() {
             // provide an index jelly view
-            return new View.People(Jenkins.getInstance());
+            return new View.People(Jenkins.get());
         }
     }
     
@@ -277,7 +277,7 @@ public class GetterMethodFilterTest extends StaplerAbstractTest {
     @TestExtension
     public static class TestWithReturnPluginObject extends AbstractUnprotectedRootAction {
         public Folder getFolder() {
-            return new Folder(Jenkins.getInstance(), "testFolder");
+            return new Folder(Jenkins.get(), "testFolder");
         }
     }
     

--- a/test/src/test/java/jenkins/triggers/ReverseBuildTriggerTest.java
+++ b/test/src/test/java/jenkins/triggers/ReverseBuildTriggerTest.java
@@ -222,7 +222,7 @@ public class ReverseBuildTriggerTest {
 
         // The reported issue was with Pipeline jobs, which calculate their dependency graphs via
         // ReverseBuildTrigger.RunListenerImpl, so an additional test may be needed downstream.
-        trigger.buildDependencyGraph(downstreamJob1, Jenkins.getInstance().getDependencyGraph());
+        trigger.buildDependencyGraph(downstreamJob1, Jenkins.get().getDependencyGraph());
     }
 
     @Issue("JENKINS-46161")

--- a/test/src/test/java/lib/form/RepeatablePropertyTest.java
+++ b/test/src/test/java/lib/form/RepeatablePropertyTest.java
@@ -152,7 +152,7 @@ public class RepeatablePropertyTest extends HudsonTestCase implements Describabl
             return greatProperty;
         }
         public Descriptor<ExcitingObject> getDescriptor() {
-            return Jenkins.getInstance().getDescriptor(ExcitingObject.class);
+            return Jenkins.get().getDescriptor(ExcitingObject.class);
         }
         @Override
         public boolean equals(Object o) {

--- a/test/src/test/java/lib/form/RepeatableTest.java
+++ b/test/src/test/java/lib/form/RepeatableTest.java
@@ -301,7 +301,7 @@ public class RepeatableTest extends HudsonTestCase {
         private Fruit(String name) { this.name = name; }
 
         public Descriptor<Fruit> getDescriptor() {
-            return Jenkins.getInstance().getDescriptor(getClass());
+            return Jenkins.get().getDescriptor(getClass());
         }
     }
 

--- a/test/src/test/java/lib/form/ValidateButtonTest.java
+++ b/test/src/test/java/lib/form/ValidateButtonTest.java
@@ -90,7 +90,7 @@ public class ValidateButtonTest {
         }
     
         public DescriptorImpl getDescriptor() {
-            return Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
+            return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
         }
     
         @Extension
@@ -190,7 +190,7 @@ public class ValidateButtonTest {
         }
         
         public DescriptorImpl getDescriptor() {
-            return Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
+            return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
         }
         
         @Extension

--- a/war/src/main/webapp/WEB-INF/security/AbstractPasswordBasedSecurityRealm.groovy
+++ b/war/src/main/webapp/WEB-INF/security/AbstractPasswordBasedSecurityRealm.groovy
@@ -37,7 +37,7 @@ authenticationManager(ProviderManager) {
 
         // these providers apply everywhere
         bean(RememberMeAuthenticationProvider) {
-            key = Jenkins.getInstance().getSecretKey();
+            key = Jenkins.get().getSecretKey();
         },
         // this doesn't mean we allow anonymous access.
         // we just authenticate anonymous users as such,


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4042
See [JENKINS-57678](https://issues.jenkins-ci.org/browse/JENKINS-57678).

### Proposed changelog entries

The method Jenkins.getInstance() is deprecated, and the recommendation is to use the get method instead.

### Submitter checklist

- [x] JIRA issue is well described

