### PR TITLE
Mirror of jenkinsci jenkins#4060

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -534,7 +534,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>4.5.2</version>
+      <version>5.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -1442,7 +1442,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                      * Read the remainder of psinfo_t differently depending on whether the
                      * Java process is 32-bit or 64-bit.
                      */
-                    if (Pointer.SIZE == 8) {
+                    if (Native.POINTER_SIZE == 8) {
                         psinfo.seek(236);  // offset of pr_argc
                         argc = adjust(psinfo.readInt());
                         argp = adjustL(psinfo.readLong());

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -26,7 +26,6 @@ package hudson.util;
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
-import com.sun.jna.Pointer;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.ptr.IntByReference;
 import hudson.EnvVars;

--- a/core/src/main/java/hudson/util/jna/Kernel32Utils.java
+++ b/core/src/main/java/hudson/util/jna/Kernel32Utils.java
@@ -115,7 +115,7 @@ public class Kernel32Utils {
     public static File getTempDir() {
         Memory buf = new Memory(1024);
         if (Kernel32.INSTANCE.GetTempPathW(512,buf)!=0) {// the first arg is number of wchar
-            return new File(buf.getString(0, true));
+            return new File(buf.getWideString(0));
         } else {
             return null;
         }


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4060
This solves problems with loading native librarie of JNA on AIX
platform when using openJDK or other JDKs that assume .so is the
extension for shared libraries (https://github.com/java-native-access/jna/issues/1066)

See [JENKINS-57515](https://issues.jenkins-ci.org/browse/JENKINS-57515).

### Proposed changelog entries

* Update JNA from 4.5.2 to 5.3.1 to fix issue with shared library loading on AIX when using OpenJDK

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

