### PR TITLE
Mirror of jenkinsci jenkins#4059

### DIFF
--- a/core/src/main/java/jenkins/util/io/PathRemover.java
+++ b/core/src/main/java/jenkins/util/io/PathRemover.java
@@ -24,18 +24,13 @@
 
 package jenkins.util.io;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.Functions;
-import hudson.Util;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
@@ -44,6 +39,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Functions;
+import hudson.Util;
 
 @Restricted(NoExternalUse.class)
 public class PathRemover {
@@ -285,6 +289,15 @@ public class PathRemover {
             } catch (UnsupportedOperationException ignored) {
                 // PosixFileAttributes not supported, fall back to old IO.
             }
+        } else {
+          /*
+           * If on Windows a folder has a read only attribute set, the file.setWritable(true) doesn't work (JENKINS-57855)
+           */
+          DosFileAttributeView dos = Files.getFileAttributeView(path, DosFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+          if (dos != null)
+          {
+            dos.setReadOnly(false);
+          }
         }
 
         /*


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4059
See [JENKINS-57855](https://issues.jenkins-ci.org/browse/JENKINS-57855).

### Proposed changelog entries

* Fix: reliably remove read-only flag for windows folders

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


