### PR TITLE
Mirror of jenkinsci jenkins#4063

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -207,7 +207,7 @@ THE SOFTWARE.
     <dependency><!-- JENKINS-21160: remoting also depends on args4j, please update accordingly -->
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.0.31</version>
+      <version>2.33</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4063
Depends on jenkinsci/remoting#329. Blocks jenkinsci/swarm-plugin#120. See jenkinsci/remoting#326 for an explanation of the main API change and the testing done.
