### PR TITLE
Mirror of jenkinsci jenkins#4062

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -154,10 +154,6 @@
               </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -83,8 +83,8 @@
       <version>build214-jenkins-1</version>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -156,8 +156,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -596,7 +596,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -805,10 +805,6 @@ THE SOFTWARE.
             </manifest>
           </archive>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -594,8 +594,8 @@ THE SOFTWARE.
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -807,8 +807,8 @@ THE SOFTWARE.
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
@@ -872,11 +872,11 @@ THE SOFTWARE.
       </build>
     </profile>
     <profile>
-      <!-- Run FindBugs for better error detection. Run as "mvn -Pfindbugs install site". -->
-      <!-- FindBugs has been moved to the default build flow, but here we fail the build on errors-->
-      <id>findbugs</id>
+      <!-- Run SpotBugs for better error detection. Run as "mvn -Pspotbugs install site". -->
+      <!-- SpotBugs has been moved to the default build flow, but here we fail the build on errors-->
+      <id>spotbugs</id>
       <properties>
-        <!-- In the default profile we always fail the build if there FindBugs errors -->
+        <!-- In the default profile we always fail the build if there SpotBugs errors -->
         <findbugs.failOnError>true</findbugs.failOnError>
       </properties>
     </profile>

--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -23,6 +23,7 @@
  */
 package jenkins.security.apitoken;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.User;
@@ -112,6 +113,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
      */
     // used by Jelly view
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public boolean hasFreshToken(@Nonnull User user, @Nullable ApiTokenProperty.TokenInfoAndStats legacyStats) {
         if (legacyStats == null) {
             return false;
@@ -136,6 +138,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
      */
     // used by Jelly view
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public boolean hasMoreRecentlyUsedToken(@Nonnull User user, @Nullable ApiTokenProperty.TokenInfoAndStats legacyStats) {
         if (legacyStats == null) {
             return false;

--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -23,7 +23,7 @@
  */
 package jenkins.security.apitoken;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.User;
@@ -38,7 +38,6 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.json.JsonBody;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
@@ -90,14 +89,14 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     
     // used by Jelly view
     @Restricted(NoExternalUse.class)
-    public @Nullable ApiTokenStore.HashedToken getLegacyTokenOf(@Nonnull User user) {
+    public @CheckForNull ApiTokenStore.HashedToken getLegacyTokenOf(@Nonnull User user) {
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
         return apiTokenProperty.getTokenStore().getLegacyToken();
     }
     
     // used by Jelly view
     @Restricted(NoExternalUse.class)
-    public @Nullable ApiTokenProperty.TokenInfoAndStats getLegacyStatsOf(@Nonnull User user, @Nullable ApiTokenStore.HashedToken legacyToken) {
+    public @CheckForNull ApiTokenProperty.TokenInfoAndStats getLegacyStatsOf(@Nonnull User user, @CheckForNull ApiTokenStore.HashedToken legacyToken) {
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
         if (legacyToken != null) {
             ApiTokenStats.SingleTokenStats legacyStats = apiTokenProperty.getTokenStats().findTokenStatsById(legacyToken.getUuid());
@@ -113,8 +112,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
      */
     // used by Jelly view
     @Restricted(NoExternalUse.class)
-    @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public boolean hasFreshToken(@Nonnull User user, @Nullable ApiTokenProperty.TokenInfoAndStats legacyStats) {
+    public boolean hasFreshToken(@Nonnull User user, @CheckForNull ApiTokenProperty.TokenInfoAndStats legacyStats) {
         if (legacyStats == null) {
             return false;
         }
@@ -138,8 +136,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
      */
     // used by Jelly view
     @Restricted(NoExternalUse.class)
-    @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public boolean hasMoreRecentlyUsedToken(@Nonnull User user, @Nullable ApiTokenProperty.TokenInfoAndStats legacyStats) {
+    public boolean hasMoreRecentlyUsedToken(@Nonnull User user, @CheckForNull ApiTokenProperty.TokenInfoAndStats legacyStats) {
         if (legacyStats == null) {
             return false;
         }

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -289,6 +289,10 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
             }
             for (final ReverseBuildTrigger trigger : triggers) {
                 if (trigger.shouldTrigger(r, listener)) {
+                    // Make SpotBugs happy.
+                    if (trigger.job == null) {
+                        continue;
+                    }
                     if (!trigger.job.isBuildable()) {
                         listener.getLogger().println(hudson.tasks.Messages.BuildTrigger_Disabled(ModelHyperlinkNote.encodeTo(trigger.job)));
                         continue;

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.51</version>
+    <version>1.52</version>
     <relativePath />
   </parent>
 
@@ -630,8 +630,8 @@ THE SOFTWARE.
       <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>findbugs-maven-plugin</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
             <configuration>
               <threshold>High</threshold>
             </configuration>

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -43,6 +43,16 @@ THE SOFTWARE.
     <jacocoSurefireArgs /><!-- empty by default -->
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>annotations</artifactId>
+        <version>3.0.1</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4062
Updated the parent POM to [the latest version](https://github.com/jenkinsci/pom/releases), which has SpotBugs support, and migrated any remaining POM references from FindBugs to SpotBugs. This exposed the following new SpotBugs error:

```
[ERROR] Possible null pointer dereference of hudson.triggers.Trigger.job in jenkins.triggers.ReverseBuildTrigger$RunListenerImpl.onCompleted(Run, TaskListener) [jenkins.triggers.ReverseBuildTrigger$RunListenerImpl, jenkins.triggers.ReverseBuildTrigger$RunListenerImpl] Dereferenced at ReverseBuildTrigger.java:[line 292]Known null at ReverseBuildTrigger.java:[line 292] NP_NULL_ON_SOME_PATH
```

Looking at the code, this seems like a false positive, because it is wrapped in the conditional `if (trigger.shouldTrigger(r, listener)) {`, and `shouldTrigger` returns `false` if `job` is null. SpotBugs doesn't seem to be able to detect this. To silence the error, I added an explicit null check (which is harmless).

The only other issue I had was this `RequireUpperBoundDeps` error:

```
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (display-info) <at> jenkins-test-parent ---
[INFO] Ignoring requireUpperBoundDeps in org.apache.maven:maven-embedder
[INFO] Ignoring requireUpperBoundDeps in org.codehaus.plexus:plexus-classworlds
[INFO] Ignoring requireUpperBoundDeps in org.apache.maven:maven-core
[INFO] Ignoring requireUpperBoundDeps in org.apache.maven:maven-aether-provider
[INFO] Ignoring requireUpperBoundDeps in org.codehaus.plexus:plexus-utils
[WARNING] Rule 3: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.google.code.findbugs:annotations:2.0.1 paths to dependency are:
+-org.jenkins-ci.main:jenkins-test-parent:2.181-SNAPSHOT
  +-org.reflections:reflections:0.9.9
    +-com.google.code.findbugs:annotations:2.0.1
and
+-org.jenkins-ci.main:jenkins-test-parent:2.181-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.181-SNAPSHOT
    +-org.jenkins-ci.main:jenkins-core:2.181-SNAPSHOT
      +-org.jenkins-ci:version-number:1.6
        +-com.google.code.findbugs:annotations:3.0.0
```

I fixed this by adding a `<dependencyManagement>` section to `test-pom/pom.xml` and pinning the dependency at the higher version with `provided` scope. The latter could technically be done in [jenkinsci/pom](https://github.com/jenkinsci/pom) itself, but I am setting that aside for a future cleanup once we are cleanly migrated to SpotBugs.

### Proposed changelog entries

Internal: Switch from FindBugs to SpotBugs for static analysis.
