### PR TITLE
Mirror of jenkinsci jenkins#4094

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -338,7 +338,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     @Override
     @Nonnull
     public Set<User> calculateCulprits() {
-        Set<User> c = RunWithSCM.super.calculateCulprits();
+        Set<User> users = RunWithSCM.super.calculateCulprits();
 
         AbstractBuild<P,R> p = getPreviousCompletedBuild();
         if (upstreamCulprits) {
@@ -349,14 +349,14 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 for (AbstractBuild.DependencyChange dep : depmap.values()) {
                     for (AbstractBuild<?, ?> b : dep.getBuilds()) {
                         for (ChangeLogSet.Entry entry : b.getChangeSet()) {
-                            c.add(entry.getAuthor());
+                            users.add(entry.getAuthor());
                         }
                     }
                 }
             }
         }
 
-        return c;
+        return users;
     }
 
     /**

--- a/core/src/main/java/hudson/scm/ChangeLogSet.java
+++ b/core/src/main/java/hudson/scm/ChangeLogSet.java
@@ -206,6 +206,17 @@ public abstract class ChangeLogSet<T extends ChangeLogSet.Entry> implements Iter
         public abstract User getAuthor();
 
         /**
+         * Get from commit additional information
+         *
+         * <p>
+         * The exact definition depends on the individual SCM implementation
+         * @return
+         *     Can be empty
+         */
+        @Exported
+        public abstract String getComment();
+
+        /**
          * Returns a set of paths in the workspace that was
          * affected by this change.
          *


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4094
See [JENKINS-49202](https://issues.jenkins-ci.org/browse/JENKINS-49202).

### Proposed changelog entries

* Entry 1: Exposed getComment method in ChangeLogSet.Entry

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

Component: Internal. Because not affected some audience.
No test, because is redundant in this case. So if need it let me know.
No dependency updates


### Desired reviewers

<at>oleg-nenashev 

