### PR TITLE
Mirror of jenkinsci jenkins#4090

### DIFF
--- a/core/src/main/resources/hudson/model/Run/delete.jelly
+++ b/core/src/main/resources/hudson/model/Run/delete.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${!it.building}">
-    <l:task href="${buildUrl.baseUrl}/confirmDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%delete.build(it.displayName)}"/>
+    <l:task href="${buildUrl.baseUrl}/confirmDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%Delete this build}"/>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Run/delete.properties
+++ b/core/src/main/resources/hudson/model/Run/delete.properties
@@ -21,4 +21,3 @@
 # THE SOFTWARE.
 
 Delete\ this\ build=Delete Build
-delete.build=Delete build \u2018{0}\u2019


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4090
donot add build displayName to the "delete build" button

fix "delete build" button too long,https://issues.jenkins-ci.org/browse/JENKINS-58157

this issue come from this commit: [JENKINS-55848] Identify the name of the thing being deleted (#3871)
revert  core/src/main/resources/hudson/model/Run/delete.jelly
revert  core/src/main/resources/hudson/model/Run/delete.properties

Signed-off-by: Mamh-Linux <bright.ma<at>blackshark.com>

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<at>mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

