### PR TITLE
Mirror of jenkinsci jenkins#4089

### DIFF
--- a/licenseCompleter.groovy
+++ b/licenseCompleter.groovy
@@ -48,7 +48,7 @@ complete {
         rewriteLicense([], license("BSD License","http://jaxen.codehaus.org/license.html"))
     }
 
-    match("*:dom4j") {
+    match("org.jenkins-ci.dom4j:dom4j") {
         rewriteLicense([],license("BSD License","http://dom4j.sourceforge.net/dom4j-1.6.1/license.html"))
     }
 

--- a/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
+++ b/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
@@ -95,8 +95,8 @@ public class JnlpAccessWithSecuredHudsonTest {
         XmlPage jnlp = (XmlPage) wc.goTo("computer/test/slave-agent.jnlp","application/x-java-jnlp-file");
         URL baseUrl = jnlp.getUrl();
         Document dom = new DOMReader().read(jnlp.getXmlDocument());
-        for( Element jar : (List<Element>)dom.selectNodes("//jar") ) {
-            URL url = new URL(baseUrl,jar.attributeValue("href"));
+        for( Object jar : dom.selectNodes("//jar") ) {
+            URL url = new URL(baseUrl,((org.dom4j.Element)jar).attributeValue("href"));
             System.out.println(url);
             
             // now make sure that these URLs are unprotected


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4089
Changes to enable Jenkins to use either the standard, current dom4j release or the Jenkins-custom fork. This allows us to separately remove the fork and reference the standard one.

See [JENKINS-53322](https://issues.jenkins-ci.org/browse/JENKINS-53322).

I've been working on eliminating the need for the Jenkins-specific fork of dom4j and adopting the latest, standard release, 2.1.1. This PR makes two small changes, which enable Jenkins to work with either the antiquated or current dom4j versions.

1. There was a change to the dom4j API during all this time. JnlpAccessWithSecuredHudsonTest in jenkins/test needs a small change to be able to run on old or new versions. This is similar to a PR I recently submitted and was merged in ec2-plugin.
2. There is custom handling in licenseCompleter.groovy for the license for the old dom4j fork. By specifying the group ID, the custom handling will apply for the fork or the standard mechanisms will work for the standard releases.

See also jenkinsci/ec2-plugin#372 for similar cross-version compatibility tweaks. 

See stapler/stapler#164 for changes that remove the dependency on the Jenkins-specific fork and move to the current latest release. That Stapler change cannot be incorporated into Jenkins until this PR is merged, but this PR has no dependency on any other change.

After the other necessary PRs are merged and released, I will submit a new PR to use a Stapler release referencing the latest, standard dom4j library.

### Proposed changelog entries

* Internal: Prepare for using latest dom4j library. ([issue 53332](https://issues.jenkins-ci.org/browse/JENKINS-53322))

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

