### PR TITLE
Mirror of jenkinsci jenkins#4098

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -84,6 +84,7 @@ import static hudson.PluginWrapper.PluginDisableStatus.ERROR_DISABLING;
 import static hudson.PluginWrapper.PluginDisableStatus.NOT_DISABLED_DEPENDANTS;
 import static hudson.PluginWrapper.PluginDisableStatus.NO_SUCH_PLUGIN;
 import static java.util.logging.Level.WARNING;
+import jenkins.plugins.DetachedPluginsUtil;
 import static org.apache.commons.io.FilenameUtils.getBaseName;
 
 /**
@@ -997,6 +998,14 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     @Exported
     public boolean isDeleted() {
         return !archive.exists();
+    }
+
+    /**
+     * Same as {@link DetachedPluginsUtil#isDetachedPlugin}.
+     */
+    @Exported
+    public boolean isDetached() {
+        return DetachedPluginsUtil.isDetachedPlugin(shortName);
     }
 
     /**

--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -290,6 +290,11 @@ Behaviour.specify("#filter-box", '_table', 0, function(e) {
                     return true;
                 }
             }
+
+            if (pluginTR.hasClassName('detached')) {
+                infoContainer.update('<div class="title">' + i18n('detached-disable') + '</div><div class="subtitle">' + i18n('detached-possible-dependents') + '</div>');
+                return true;
+            }
             
             return false;
         }
@@ -318,6 +323,11 @@ Behaviour.specify("#filter-box", '_table', 0, function(e) {
                 return true;
             }
             
+            if (pluginTR.hasClassName('detached')) {
+                infoContainer.update('<div class="title">' + i18n('detached-uninstall') + '</div><div class="subtitle">' + i18n('detached-possible-dependents') + '</div>');
+                return true;
+            }
+
             return false;
         }
 

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -50,6 +50,9 @@ THE SOFTWARE.
              data-disabled-dependencies="${%It has one or more disabled dependencies}" 
              data-enabled-dependents="${%It has one or more enabled dependents}" 
              data-installed-dependents="${%It has one or more installed dependents}" 
+             data-detached-disable="${%detached-disable}"
+             data-detached-uninstall="${%detached-uninstall}"
+             data-detached-possible-dependents="${%detached-possible-dependents}"
         />
         <table id="plugins" class="pane bigtable sortable stripped-odd">
           <j:choose>
@@ -67,7 +70,7 @@ THE SOFTWARE.
                 <th width="1">${%Uninstall}</th>
               </tr>
               <j:forEach var="p" items="${app.pluginManager.plugins}">
-                <tr class="plugin ${p.hasMandatoryDependents()?'has-dependents':''} ${(p.hasMandatoryDependents() &amp;&amp; !p.enabled)?'has-dependents-but-disabled':''} ${p.isDeleted()?'deleted':''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
+                <tr class="plugin ${p.hasMandatoryDependents()?'has-dependents':''} ${(p.hasMandatoryDependents() and !p.enabled)?'has-dependents-but-disabled':''} ${p.isDeleted()?'deleted':''} ${p.detached and p.enabled ? 'detached' : ''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
                   <j:set var="state" value="${p.enabled?'true':null}"/>
                   <td class="center pane enable" data="${state}">
                     <input type="checkbox" checked="${state}" onclick="flip(event)"

--- a/core/src/main/resources/hudson/PluginManager/installed.properties
+++ b/core/src/main/resources/hudson/PluginManager/installed.properties
@@ -21,3 +21,6 @@
 # THE SOFTWARE.
 downgradeTo=Downgrade to {0}
 requires.restart=This Jenkins instance requires a restart. Changing the state of plugins at this time is strongly discouraged. Restart Jenkins before proceeding.
+detached-disable=This plugin may not be safe to disable
+detached-uninstall=This plugin may not be safe to uninstall
+detached-possible-dependents=Its functionality was at one point moved out of Jenkins core, and another plugin with a core dependency predating the split may be relying on it implicitly.


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4098
As discussed in https://github.com/jenkinsci/jenkins/pull/4001#issuecomment-507722786 ([JENKINS-33843](https://issues.jenkins-ci.org/browse/JENKINS-33843)). The warning is displayed only for a plugin which is in the detached list (whether or not it has since been upgraded, or was even installed this way to begin with); which is currently enabled (otherwise presumably it is too late); and for which there was not already an informational row about enabled mandatory dependents which would have been disabling the enablement checkbox and **Uninstall** button. In this example, these conditions select `matrix-auth` and `matrix-project`:

![detached](https://user-images.githubusercontent.com/154109/60620951-7ab20900-9daa-11e9-9a80-a76a0bd11178.png)

### Proposed changelog entries

* Added a warning to the **Installed** tab of the plugin manager alerting administrators to possible problems from disabling detached plugins, which became possible as of 2.181.
