### PR TITLE
Mirror of jenkinsci jenkins#4096

### DIFF
--- a/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
+++ b/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
@@ -269,6 +269,14 @@ public class TokenBasedRememberMeServices2 extends TokenBasedRememberMeServices 
                 userDetails.getAuthorities());
         auth.setDetails(authenticationDetailsSource.buildDetails(request));
 
+        // Ensure this session is linked to the user's seed
+        if (!UserSeedProperty.DISABLE_USER_SEED) {
+            User user = User.get(auth);
+            UserSeedProperty userSeed = user.getProperty(UserSeedProperty.class);
+            String sessionSeed = userSeed.getSeed();
+            request.getSession().setAttribute(UserSeedProperty.USER_SESSION_SEED, sessionSeed);
+        }
+
         return auth;
     }
 

--- a/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
+++ b/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
@@ -32,7 +32,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.kohsuke.stapler.Stapler;
 import org.springframework.dao.DataAccessException;
+import test.security.realm.InMemorySecurityRealm;
 
+import javax.annotation.concurrent.GuardedBy;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
@@ -293,10 +295,13 @@ public class TokenBasedRememberMeServices2Test {
 
     @Test
     @Issue("JENKINS-56243")
-    public void rememberMeToken_shouldSetUserSeedInSession() throws Exception {
+    public void rememberMeToken_shouldLoadUserDetailsOnlyOnce() throws Exception {
         j.jenkins.setDisableRememberMe(false);
-        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        LoadUserCountingSecurityRealm realm = new LoadUserCountingSecurityRealm();
+        realm.createAccount("alice");
+        j.jenkins.setSecurityRealm(realm);
         User alice = User.getOrCreateByIdOrFullName("alice");
+        realm.verifyInvocations(1);
 
         // first, start a session with a remember me token
         Cookie cookie = getRememberMeCookie(j.createWebClient().login("alice", "alice", true));
@@ -305,9 +310,32 @@ public class TokenBasedRememberMeServices2Test {
         wc.getCookieManager().addCookie(cookie);
         // trigger remember me
         String sessionSeed = wc.executeOnServer(() -> Stapler.getCurrentRequest().getSession(false).getAttribute(UserSeedProperty.USER_SESSION_SEED).toString());
+        realm.verifyInvocations(1);
         String userSeed = alice.getProperty(UserSeedProperty.class).getSeed();
 
         assertEquals(userSeed, sessionSeed);
+
+        // finally, ensure that loadUserByUsername is not being called anymore
+        wc.goTo("");
+        assertUserConnected(wc, "alice");
+        realm.verifyInvocations(0);
+    }
+
+    private static class LoadUserCountingSecurityRealm extends InMemorySecurityRealm {
+        // if this class wasn't serialized into config.xml, this could be replaced by @Spy from Mockito
+        @GuardedBy("this")
+        private int counter = 0;
+
+        @Override
+        public synchronized UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
+            ++counter;
+            return super.loadUserByUsername(username);
+        }
+
+        synchronized void verifyInvocations(int count) {
+            assertEquals(count, counter);
+            counter = 0;
+        }
     }
 
     private Cookie createRememberMeCookie(TokenBasedRememberMeServices2 tokenService, long deltaDuration, hudson.model.User user) throws Exception {


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4096
This fixes the remember me service to link the user seed to a
corresponding HTTP session. By doing so, this should significantly
reduce the number of calls to loadUserDetails().

See [JENKINS-56243](https://issues.jenkins-ci.org/browse/JENKINS-56243).

### Proposed changelog entries

* Fixed performance regression in the remember me service introduced by SECURITY-868.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<at>reviewbybees <at>jeffret-b <at>Wadeck <at>daniel-beck <at>jenkinsci/code-reviewers 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

