### PR TITLE
Mirror of jenkinsci jenkins#4115

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -733,7 +733,7 @@ LABEL.attach-previous {
     padding-left: 20px;
     min-height: 16px;
     line-height: 16px;
-    background-image: url( "../images/16x16/warning.png" );
+    background-image: url("../images/16x16/warning.png");
     background-size: 16px 16px;
     background-position: left center;
     background-repeat: no-repeat;
@@ -749,7 +749,7 @@ LABEL.attach-previous {
     font-weight: bold;
     padding-left: 20px;
     min-height: 16px;
-    background-image: url( "../images/16x16/go-next.png" ); /* TODO: get a better icon */
+    background-image: url("../images/16x16/go-next.png"); /* TODO: get a better icon */
     background-position: left center;
     background-repeat: no-repeat;
 }


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4115
During proxy debugging in a huge log i found such repeating errors
```
"GET /static/414610c3/css/%20%22../images/16x16/go-next.png%22 HTTP/1.1" 404
"GET /static/414610c3/css/%20%22../images/16x16/warning.png%22 HTTP/1.1" 404
```

I was unable to reproduce myself, but found only this place of code inconsistent to other `url` elements. CSS3 specification is missing mentions about allowed extra whitespace after `url(` while 2.1 had.

I think change wouldn't break anything and will fix some ancient style/forms using this icons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/4115)
<!-- Reviewable:end -->

