### PR TITLE
Mirror of jenkinsci jenkins#4129

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,6 +106,7 @@ infra.maybePublishIncrementals()
 void withMavenEnv(List envVars = [], def buildType, def javaVersion, def body) {
     if (buildType == 'Linux') {
         // I.e., a Maven container using ACI. No need to install tools.
+        sh 'apt-get update && apt-get install -y git libfontconfig1 libfreetype6' // TODO pending https://github.com/jenkinsci/jnlp-agents/pull/5
         return withEnv(envVars) {
             body.call()
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,6 @@
 /*
  * This Jenkinsfile is intended to run on https://ci.jenkins.io and may fail anywhere else.
  * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
- *
- * The required labels are "java" and "docker" - "java" would be any node that can run Java builds. It doesn't need
- * to have Java installed, but some setups may have nodes that shouldn't have heavier builds running on them, so we
- * make this explicit. "docker" would be any node with docker installed.
  */
 
 // TEST FLAG - to make it easier to turn on/off unit tests for speeding up access to later stuff.
@@ -15,7 +11,6 @@ def failFast = false
 
 properties([buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '3')), durabilityHint('PERFORMANCE_OPTIMIZED')])
 
-// see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc for information on what node types are available
 def buildTypes = ['Linux', 'Windows']
 def jdks = [8, 11]
 
@@ -25,7 +20,8 @@ for(j = 0; j < jdks.size(); j++) {
     def buildType = buildTypes[i]
     def jdk = jdks[j]
     builds["${buildType}-jdk${jdk}"] = {
-        node(buildType.toLowerCase()) {
+        // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available
+        node(buildType == 'Linux' ? (jdk == 8 ? 'maven' : 'maven-11') : buildType.toLowerCase()) {
                 // First stage is actually checking out the source. Since we're using Multibranch
                 // currently, we can use "checkout scm".
                 stage('Checkout') {
@@ -41,7 +37,7 @@ for(j = 0; j < jdks.size(); j++) {
                         // See below for what this method does - we're passing an arbitrary environment
                         // variable to it so that JAVA_OPTS and MAVEN_OPTS are set correctly.
                         withMavenEnv(["JAVA_OPTS=-Xmx1536m -Xms512m",
-                                    "MAVEN_OPTS=-Xmx1536m -Xms512m"], jdk) {
+                                    "MAVEN_OPTS=-Xmx1536m -Xms512m"], buildType, jdk) {
                             // Actually run Maven!
                             // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
                             def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
@@ -107,7 +103,14 @@ infra.maybePublishIncrementals()
 // This method sets up the Maven and JDK tools, puts them in the environment along
 // with whatever other arbitrary environment variables we passed in, and runs the
 // body we passed in within that environment.
-void withMavenEnv(List envVars = [], def javaVersion, def body) {
+void withMavenEnv(List envVars = [], def buildType, def javaVersion, def body) {
+    if (buildType == 'Linux') {
+        // I.e., a Maven container using ACI. No need to install tools.
+        return withEnv(envVars) {
+            body.call()
+        }
+    }
+    
     // The names here are currently hardcoded for my test environment. This needs
     // to be made more flexible.
     // Using the "tool" Workflow call automatically installs those tools on the

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,6 @@ infra.maybePublishIncrementals()
 void withMavenEnv(List envVars = [], def buildType, def javaVersion, def body) {
     if (buildType == 'Linux') {
         // I.e., a Maven container using ACI. No need to install tools.
-        sh 'apt-get update && apt-get install -y git libfontconfig1 libfreetype6' // TODO pending https://github.com/jenkinsci/jnlp-agents/pull/5
         return withEnv(envVars) {
             body.call()
         }

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -54,16 +54,19 @@ import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
+import org.junit.ClassRule;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 public class ArtifactArchiverTest {
-    
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public JenkinsRule j = new JenkinsRule();
 
     @Test
@@ -312,6 +315,7 @@ public class ArtifactArchiverTest {
         p.setAssignedNode(slave);
 
         FreeStyleBuild build = p.scheduleBuild2(0).get();
+        assumeFalse(FILENAME + " should not be readable by " + System.getProperty("user.name"), new File(build.getWorkspace().child(FILENAME).getRemote()).canRead());
         j.assertBuildStatus(Result.FAILURE, build);
         String expectedPath = build.getWorkspace().child(FILENAME).getRemote();
         j.assertLogContains("ERROR: Step ‘Archive the artifacts’ failed: java.nio.file.AccessDeniedException: " + expectedPath, build);

--- a/test/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
@@ -95,16 +95,18 @@ public class JenkinsBuildsAndWorkspacesDirectoriesTest {
     @Test
     public void badValueForBuildsDir() {
         story.then((rule) -> {
-            final List<String> badValues = Arrays.asList(
+            final List<String> badValues = new ArrayList<>(Arrays.asList(
                     "blah",
                     "$JENKINS_HOME",
                     "$JENKINS_HOME/builds",
                     "$ITEM_FULL_NAME",
                     "/path/to/builds",
                     "/invalid/$JENKINS_HOME",
-                    "relative/ITEM_FULL_NAME",
-                    "/foo/$ITEM_FULL_NAME",
-                    "/$ITEM_FULLNAME");
+                    "relative/ITEM_FULL_NAME"));
+            if (!new File("/").canWrite()) {
+                badValues.add("/foo/$ITEM_FULL_NAME");
+                badValues.add("/$ITEM_FULLNAME");
+            } // else perhaps running as root
 
             for (String badValue : badValues) {
                 try {


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4129
The Azure Container Instances agents seem to scale better than the `linux` agents, which may help alleviate pressure on the ci.jenkins.io queue. There will still be congestion on the Windows branches, and the ATH branch still uses a VM with Docker support (no core functional tests are yet Dockerized).

We can avoid using `tool` installers and come closer to declarative infrastructure: changes to the environment can be proposed via `Dockerfile` PRs. Unfortunately there is no version tracking—you still just get whatever image was most recently deployed—so from a reproducibility perspective this is only marginally better than the current situation, but much worse than using the `docker` label and running the build inside a container with an explicitly specified image.

### Proposed changelog entries

* None needed, this is an internal change.
