### PR TITLE
Mirror of jenkinsci jenkins#4177

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -264,7 +264,7 @@ public class CLI {
         if (userInfo != null) {
             factory = factory.basicAuth(userInfo);
         } else if (auth != null) {
-            factory = factory.basicAuth(auth.startsWith("@") ? FileUtils.readFileToString(new File(auth.substring(1))).trim() : auth);
+            factory = factory.basicAuth(auth.startsWith("@") ? FileUtils.readFileToString(new File(auth.substring(1)), (Charset) null).trim() : auth);
         }
 
         if (mode == Mode.HTTP) {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -23,6 +23,7 @@
  */
 package hudson;
 
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.PluginWrapper.Dependency;
@@ -209,8 +210,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     private enum PMConstructor {
         JENKINS {
             @Override
-            @NonNull PluginManager doCreate(@NonNull Class<? extends PluginManager> klass,
-                                            @NonNull Jenkins jenkins) throws ReflectiveOperationException {
+            @NonNull
+            PluginManager doCreate(@NonNull Class<? extends PluginManager> klass,
+                                   @NonNull Jenkins jenkins) throws ReflectiveOperationException {
                 return klass.getConstructor(Jenkins.class).newInstance(jenkins);
             }
         },

--- a/core/src/main/java/hudson/util/DoubleLaunchChecker.java
+++ b/core/src/main/java/hudson/util/DoubleLaunchChecker.java
@@ -39,6 +39,7 @@ import static hudson.init.InitMilestone.JOB_LOADED;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -100,7 +101,7 @@ public class DoubleLaunchChecker {
         long t = timestampFile.lastModified();
         if(t!=0 && lastWriteTime!=0 && t!=lastWriteTime && !ignore) {
             try {
-                collidingId = FileUtils.readFileToString(timestampFile);
+                collidingId = FileUtils.readFileToString(timestampFile, (Charset) null);
             } catch (IOException e) {
                 LOGGER.log(Level.SEVERE, "Failed to read collision file", e);
             }

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -28,6 +28,7 @@ import static java.util.logging.Level.WARNING;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -224,7 +225,7 @@ public class InstallUtil {
         File lastExecVersionFile = getLastExecVersionFile();
         if (lastExecVersionFile.exists()) {
             try {
-                String version = FileUtils.readFileToString(lastExecVersionFile);
+                String version = FileUtils.readFileToString(lastExecVersionFile, (Charset) null);
                 // JENKINS-37438 blank will force the setup
                 // wizard regardless of current state of the system
                 if (StringUtils.isBlank(version)) {

--- a/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
+++ b/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.logging.Logger;
@@ -96,7 +97,7 @@ public class AdminWhitelistRule implements StaplerProxy {
     private boolean loadMasterKillSwitchFile(@Nonnull File f) {
         try {
             if (!f.exists())    return true;
-            return Boolean.parseBoolean(FileUtils.readFileToString(f).trim());
+            return Boolean.parseBoolean(FileUtils.readFileToString(f, (Charset) null).trim());
         } catch (IOException e) {
             LOGGER.log(WARNING, "Failed to read "+f, e);
             return false;

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -30,6 +30,7 @@ import hudson.util.ProcessTree;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.charset.Charset;
 
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
@@ -65,7 +66,7 @@ public class LauncherTest {
             assertTrue("Join did not finish promptly. The completion time (" + terminationTime + "ms) is longer than expected 15s", terminationTime < 15000);
             channels.french.call(new NoopCallable()); // this only returns after the other side of the channel has finished executing cancellation
             Thread.sleep(2000); // more delay to make sure it's gone
-            assertNull("process should be gone",ProcessTree.get().get(Integer.parseInt(FileUtils.readFileToString(tmp).trim())));
+            assertNull("process should be gone",ProcessTree.get().get(Integer.parseInt(FileUtils.readFileToString(tmp, (Charset) null).trim())));
 
             // Manual version of test: set up instance w/ one slave. Now in script console
             // new hudson.FilePath(new java.io.File("/tmp")).createLauncher(new hudson.util.StreamTaskListener(System.err)).

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -17,7 +17,7 @@ import org.mockito.stubbing.Answer;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
 import org.jvnet.hudson.test.Issue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +34,7 @@ public class PluginWrapperTest {
         PluginWrapper.Dependency dependency = new PluginWrapper.Dependency(version);
         assertEquals("plugin", dependency.shortName);
         assertEquals("0.0.2", dependency.version);
-        assertEquals(false, dependency.optional);
+        assertFalse(dependency.optional);
     }
 
     @Test
@@ -43,7 +43,7 @@ public class PluginWrapperTest {
         PluginWrapper.Dependency dependency = new PluginWrapper.Dependency(version);
         assertEquals("plugin", dependency.shortName);
         assertEquals("0.0.2", dependency.version);
-        assertEquals(true, dependency.optional);
+        assertTrue(dependency.optional);
     }
 
     @Test

--- a/core/src/test/java/hudson/model/ListViewTest.java
+++ b/core/src/test/java/hudson/model/ListViewTest.java
@@ -1,8 +1,8 @@
 package hudson.model;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -40,7 +40,7 @@ public class ListViewTest {
         when(owner.getItemGroup()).thenReturn(itemGroupOwner);
         ListView lv = new ListView("test", owner);
         ItemGroupOfNonTopLevelItem ig = Mockito.mock(ItemGroupOfNonTopLevelItem.class);
-        when(Items.getAllItems(eq(itemGroupOwner), eq(TopLevelItem.class))).thenReturn(Arrays.asList((TopLevelItem) ig));
+        when(Items.getAllItems(eq(itemGroupOwner), eq(TopLevelItem.class))).thenReturn(Arrays.asList(ig));
         when(ig.getRelativeNameFrom(any(ItemGroup.class))).thenReturn("test-item");
         lv.setRecurse(true);
         lv.add(ig);
@@ -60,7 +60,7 @@ public class ListViewTest {
         ListView view = new ListView("test", owner);
         view.setIncludeRegex(".*");
         TopLevelItem it = Mockito.mock(TopLevelItem.class);
-        List<TopLevelItem> igContent = Arrays.asList((TopLevelItem) it);
+        List<TopLevelItem> igContent = Arrays.asList(it);
         when(Items.getAllItems(eq(ig), eq(TopLevelItem.class))).thenReturn(igContent);
         when(ig.getItems()).thenReturn(igContent);
         when(it.getRelativeNameFrom(any(ItemGroup.class))).thenReturn("test-item");

--- a/core/src/test/java/hudson/slaves/ChannelPingerTest.java
+++ b/core/src/test/java/hudson/slaves/ChannelPingerTest.java
@@ -1,6 +1,6 @@
 package hudson.slaves;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;

--- a/core/src/test/java/hudson/slaves/DelegatingComputerLauncherTest.java
+++ b/core/src/test/java/hudson/slaves/DelegatingComputerLauncherTest.java
@@ -13,7 +13,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;

--- a/core/src/test/java/hudson/slaves/NodeListTest.java
+++ b/core/src/test/java/hudson/slaves/NodeListTest.java
@@ -40,6 +40,7 @@ import hudson.util.DescribableList;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Random;
 import java.util.Set;
 
@@ -131,7 +132,7 @@ public class NodeListTest {
             XmlFile x = new XmlFile(Jenkins.XSTREAM, tmp);
             x.write(nl);
 
-            String xml = FileUtils.readFileToString(tmp);
+            String xml = FileUtils.readFileToString(tmp, (Charset) null);
             System.out.println(xml);
             assertEquals(6,xml.split("\n").length);
 

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -118,7 +118,7 @@ public class AtomicFileWriterTest {
 
         // Then
         assertEquals(expectedContent.length()+3, Files.size(af.toPath()));
-        assertEquals(expectedContent+"hey", FileUtils.readFileToString(af));
+        assertEquals(expectedContent+"hey", FileUtils.readFileToString(af, (Charset) null));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class AtomicFileWriterTest {
 
         // Then
         assertTrue(Files.notExists(afw.getTemporaryPath()));
-        assertEquals(PREVIOUS, FileUtils.readFileToString(af));
+        assertEquals(PREVIOUS, FileUtils.readFileToString(af, (Charset) null));
     }
 
     @Test
@@ -143,7 +143,7 @@ public class AtomicFileWriterTest {
         } catch (IndexOutOfBoundsException e) {
         }
 
-        assertEquals(PREVIOUS, FileUtils.readFileToString(af));
+        assertEquals(PREVIOUS, FileUtils.readFileToString(af, (Charset) null));
     }
     @Test
     public void badPath() throws Exception {

--- a/core/src/test/java/hudson/util/SecretRewriterTest.java
+++ b/core/src/test/java/hudson/util/SecretRewriterTest.java
@@ -5,6 +5,7 @@ import hudson.Functions;
 import hudson.model.TaskListener;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -54,7 +55,7 @@ public class SecretRewriterTest {
         FileUtils.write(f, before);
         sr.rewrite(f, null);
         //assert after.replaceAll(System.getProperty("line.separator"), "\n").trim()==f.text.replaceAll(System.getProperty("line.separator"), "\n").trim()
-        return FileUtils.readFileToString(f).replaceAll(System.getProperty("line.separator"), "\n").trim();
+        return FileUtils.readFileToString(f, (Charset) null).replaceAll(System.getProperty("line.separator"), "\n").trim();
     }
 
     private String encryptOld(String str) throws Exception {
@@ -106,11 +107,11 @@ public class SecretRewriterTest {
         assertEquals(6, sw.rewriteRecursive(t, st));
 
         for (String p : dirs) {
-            assertTrue(MSG_PATTERN.matcher(FileUtils.readFileToString(new File(t, p + "/foo.xml")).trim()).matches());
+            assertTrue(MSG_PATTERN.matcher(FileUtils.readFileToString(new File(t, p + "/foo.xml"), (Charset) null).trim()).matches());
         }
 
         // t2 is only reachable by following a symlink. this should be covered, too
-        assertTrue(MSG_PATTERN.matcher(FileUtils.readFileToString(new File(t2, "foo.xml")).trim()).matches());
+        assertTrue(MSG_PATTERN.matcher(FileUtils.readFileToString(new File(t2, "foo.xml"), (Charset) null).trim()).matches());
     }
 
 }

--- a/core/src/test/java/hudson/util/TextFileTest.java
+++ b/core/src/test/java/hudson/util/TextFileTest.java
@@ -40,7 +40,7 @@ public class TextFileTest {
     public void tail() throws Exception {
         File f = tmp.newFile();
         FileUtils.copyURLToFile(getClass().getResource("ascii.txt"), f);
-        String whole = FileUtils.readFileToString(f);
+        String whole = FileUtils.readFileToString(f, (Charset) null);
         TextFile t = new TextFile(f);
         String tailStr = whole.substring(whole.length() - 34);
         assertEquals(tailStr, t.fastTail(tailStr.length()));

--- a/core/src/test/java/jenkins/model/JenkinsGetRootUrlTest.java
+++ b/core/src/test/java/jenkins/model/JenkinsGetRootUrlTest.java
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;

--- a/core/src/test/java/jenkins/model/NewViewLinkTest.java
+++ b/core/src/test/java/jenkins/model/NewViewLinkTest.java
@@ -2,7 +2,7 @@ package jenkins.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/core/src/test/java/jenkins/model/RunIdMigratorTest.java
+++ b/core/src/test/java/jenkins/model/RunIdMigratorTest.java
@@ -180,7 +180,7 @@ public class RunIdMigratorTest {
             if (symlink != null) {
                 notation = "→" + symlink;
             } else if (kid.isFile()) {
-                notation = "'" + FileUtils.readFileToString(kid) + "'";
+                notation = "'" + FileUtils.readFileToString(kid, (Charset) null) + "'";
             } else if (kid.isDirectory()) {
                 notation = summarize(kid);
             } else {

--- a/core/src/test/java/jenkins/model/lazy/FakeMap.java
+++ b/core/src/test/java/jenkins/model/lazy/FakeMap.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -43,7 +44,7 @@ public class FakeMap extends AbstractLazyLoadRunMap<Build> {
 
     @Override
     protected Build retrieve(File dir) throws IOException {
-        String n = FileUtils.readFileToString(new File(dir, "n")).trim();
+        String n = FileUtils.readFileToString(new File(dir, "n"), (Charset) null).trim();
         //new Exception("loading #" + n).printStackTrace();
         return new Build(Integer.parseInt(n));
     }

--- a/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
+++ b/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
@@ -3,6 +3,8 @@ package jenkins.security;
 import hudson.FilePath;
 import hudson.Functions;
 import java.io.File;
+import java.nio.charset.Charset;
+
 import org.apache.commons.io.FileUtils;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -31,7 +33,7 @@ public class DefaultConfidentialStoreTest {
         assertTrue(new File(tmp, "test").exists());
         assertTrue(new File(tmp, "master.key").exists());
 
-        assertThat(FileUtils.readFileToString(new File(tmp, "test")), not(containsString("Hello"))); // the data shouldn't be a plain text, obviously
+        assertThat(FileUtils.readFileToString(new File(tmp, "test"), (Charset) null), not(containsString("Hello"))); // the data shouldn't be a plain text, obviously
 
         if (!Functions.isWindows()) {
             assertEquals(0700, new FilePath(tmp).mode() & 0777); // should be read only

--- a/core/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
+++ b/core/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
@@ -39,6 +39,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -189,7 +190,7 @@ public class ApiTokenStatsTest {
         
         { // replace the ID_1 with ID_2 in the file
             XmlFile statsFile = ApiTokenStats.getConfigFile(tmp.getRoot());
-            String content = FileUtils.readFileToString(statsFile.getFile());
+            String content = FileUtils.readFileToString(statsFile.getFile(), (Charset) null);
             // now there are multiple times the same id in the file with different stats
             String newContentWithDuplicatedId = content.replace(ID_1, ID_2).replace(ID_3, ID_2);
             FileUtils.write(statsFile.getFile(), newContentWithDuplicatedId);

--- a/core/src/test/java/jenkins/triggers/SCMTriggerItemTest.java
+++ b/core/src/test/java/jenkins/triggers/SCMTriggerItemTest.java
@@ -1,6 +1,6 @@
 package jenkins.triggers;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Test;


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4177
I just fixed a couple of deprecation warnings. In general 
* FileUtils.readFileToString with second parameter null uses system default as it was before: https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/FileUtils.html#readFileToString(java.io.File,%20java.nio.charset.Charset)
* import static org.mockito.Matchers.any; changed to import static org.mockito.ArgumentMatchers.any;
* simplified two asserts

### Proposed changelog entries

* None needed

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers



