### PR TITLE
Mirror of jenkinsci jenkins#4176

### DIFF
--- a/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
+++ b/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
@@ -25,7 +25,7 @@ dl {
                 th(_("Message"))
             }
 
-            tam.errors.each { String trigger, SlowTriggerAdminMonitor.Value val ->
+            tam.errors.each { trigger, val ->
                 tr {
                     td(trigger)
                     td(val.time)


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4176
See [JENKINS-58938](https://issues.jenkins-ci.org/browse/JENKINS-58938).

When a slow trigger error gets reported to SlowTriggerAdminMonitor, the Jenkins UI starts to misbehave because of a Groovy compile error.

The issue can be reproduced (and fix tested) by reporting a dummy slow trigger error in the Groovy script console:

```
import hudson.triggers.SlowTriggerAdminMonitor

SlowTriggerAdminMonitor.instance.report("some trigger", "some error")
```

### Proposed changelog entries

* JENKINS-58938: Jenkins UI misbehaving when slow trigger error gets reported to the notification area/administration page.

### Submitter checklist

- [X] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests


### Desired reviewers

<at>jenkinsci/code-reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->
