### PR TITLE
Mirror of jenkinsci jenkins#4189

### DIFF
--- a/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
+++ b/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
@@ -65,12 +65,16 @@ public class AdminWhitelistRule implements StaplerProxy {
         // overwrite 30-default.conf with what we think is the best from the core.
         // this file shouldn't be touched by anyone. For local customization, use other files in the conf dir.
         // 0-byte file is used as a signal from the admin to prevent this overwriting
-        placeDefaultRule(
-                new File(jenkins.getRootDir(), "secrets/whitelisted-callables.d/default.conf"),
-                getClass().getResourceAsStream("callable.conf"));
-        placeDefaultRule(
-                new File(jenkins.getRootDir(), "secrets/filepath-filters.d/30-default.conf"),
-                transformForWindows(getClass().getResourceAsStream("filepath-filter.conf")));
+        try (InputStream collableConf = getClass().getResourceAsStream("callable.conf")) {
+            placeDefaultRule(
+                    new File(jenkins.getRootDir(), "secrets/whitelisted-callables.d/default.conf"),
+                    collableConf);
+        }
+        try (InputStream filepathFilter = getClass().getResourceAsStream("filepath-filter.conf")) {
+            placeDefaultRule(
+                    new File(jenkins.getRootDir(), "secrets/filepath-filters.d/30-default.conf"),
+                    transformForWindows(filepathFilter));
+        }
 
         this.whitelisted = new CallableWhitelistConfig(
                 new File(jenkins.getRootDir(),"secrets/whitelisted-callables.d/gui.conf"));

--- a/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
+++ b/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
@@ -61,10 +61,11 @@ public class StandardOutputSwapper extends ComputerListener {
             if (out<0)      throw new IOException("Failed to dup(1)");
             Constructor<FileDescriptor> c = FileDescriptor.class.getDeclaredConstructor(int.class);
             c.setAccessible(true);
-            FileOutputStream fos = new FileOutputStream(c.newInstance(out));
+            try (FileOutputStream fos = new FileOutputStream(c.newInstance(out))) {
 
-            // swap it into channel so that it'll use the new file descriptor
-            stdout.swap(fos);
+                // swap it into channel so that it'll use the new file descriptor
+                stdout.swap(fos);
+            }
 
             // close fd=1 (stdout) and duplicate fd=2 (stderr) into fd=1 (stdout)
             GNUCLibrary.LIBC.close(1);


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4189
See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

Fixed another Spotbugs type: [unsatisfied-obligation](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#obl-method-may-fail-to-clean-up-stream-or-resource-obl-unsatisfied-obligation)

### Proposed changelog entries

* Internal: Spotbugs issues fixed

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

