### PR TITLE
Mirror of jenkinsci jenkins#4188

### DIFF
--- a/core/src/main/java/hudson/model/RSS.java
+++ b/core/src/main/java/hudson/model/RSS.java
@@ -77,7 +77,6 @@ public final class RSS {
         req.setAttribute("title",title);
         req.setAttribute("url",url);
         req.setAttribute("entries",entries);
-        req.setAttribute("rootURL", Jenkins.get().getRootUrl());
 
         String flavor = req.getParameter("flavor");
         if(flavor==null)    flavor="atom";

--- a/core/src/main/resources/hudson/atom.jelly
+++ b/core/src/main/resources/hudson/atom.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <!-- ATOM. See http://atompub.org/rfc4287.html for the format -->
     <feed xmlns="http://www.w3.org/2005/Atom">
       <title>${title}</title>
-      <link rel="alternate" type="text/html" href="${rootURL}${url}"/>
+      <link rel="alternate" type="text/html" href="${app.rootUrl}${url}"/>
 
       <j:choose>
         <j:when test="${empty(entries)}">
@@ -46,7 +46,7 @@ THE SOFTWARE.
       <j:forEach var="e" items="${entries}" >
         <entry>
           <title>${adapter.getEntryTitle(e)}</title>
-          <link rel="alternate" type="text/html" href="${rootURL}${h.encode(adapter.getEntryUrl(e))}"/>
+          <link rel="alternate" type="text/html" href="${app.rootUrl}${h.encode(adapter.getEntryUrl(e))}"/>
           <id>${adapter.getEntryID(e)}</id>
           <published>${h.xsDate(adapter.getEntryTimestamp(e))}</published>
           <updated>${h.xsDate(adapter.getEntryTimestamp(e))}</updated>

--- a/core/src/main/resources/hudson/rss20.jelly
+++ b/core/src/main/resources/hudson/rss20.jelly
@@ -29,13 +29,13 @@ THE SOFTWARE.
     <rss version="2.0">
       <channel>
         <title>${title}</title>
-        <link>${rootURL}${url}</link>
+        <link>${app.rootUrl}${url}</link>
         <description>${title}</description>
 
         <j:forEach var="e" items="${entries}" >
           <item>
             <title>${adapter.getEntryTitle(e)}</title>
-            <link>${rootURL}${h.encode(adapter.getEntryUrl(e))}</link>
+            <link>${app.rootUrl}${h.encode(adapter.getEntryUrl(e))}</link>
             <guid isPermaLink="false">${adapter.getEntryID(e)}</guid>
             <pubDate>${h.rfc822Date(adapter.getEntryTimestamp(e))}</pubDate>
             <author><st:out value="${adapter.getEntryAuthor(e)}"/></author>

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.model;
+
+import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import hudson.model.queue.QueueTaskFuture;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class RSSTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-59167")
+    public void absoluteURLsPresentInRSS_evenWithoutRootUrlSetup() throws Exception {
+        XmlPage page = getRssPage();
+        NodeList allLinks = page.getXmlDocument().getElementsByTagName("link");
+
+        assertEquals(1, allLinks.getLength());
+        assertAllRSSLinksContainRootUrl(allLinks);
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        QueueTaskFuture<? extends Build<?, ?>> queueTaskFuture = p.scheduleBuild2(0);
+        j.assertBuildStatusSuccess(queueTaskFuture);
+
+        page = getRssPage();
+        allLinks = page.getXmlDocument().getElementsByTagName("link");
+
+        assertEquals(2, allLinks.getLength());
+        assertAllRSSLinksContainRootUrl(allLinks);
+    }
+
+    private XmlPage getRssPage() throws Exception {
+        return (XmlPage) j.createWebClient().goTo("rssAll?flavor=rss20", "text/xml");
+    }
+
+    private void assertAllRSSLinksContainRootUrl(NodeList allLinks) throws Exception {
+        for (int i = 0; i < allLinks.getLength(); i++) {
+            Node item = allLinks.item(i);
+            String url = item.getTextContent();
+            assertThat(url, containsString(j.getURL().toString()));
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-59167")
+    public void absoluteURLsPresentInAtom_evenWithoutRootUrlSetup() throws Exception {
+        XmlPage page = getAtomPage();
+        NodeList allLinks = page.getXmlDocument().getElementsByTagName("link");
+
+        assertEquals(1, allLinks.getLength());
+        assertAllAtomLinksContainRootUrl(allLinks);
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        QueueTaskFuture<? extends Build<?, ?>> queueTaskFuture = p.scheduleBuild2(0);
+        j.assertBuildStatusSuccess(queueTaskFuture);
+
+        page = getAtomPage();
+        allLinks = page.getXmlDocument().getElementsByTagName("link");
+
+        assertEquals(2, allLinks.getLength());
+        assertAllAtomLinksContainRootUrl(allLinks);
+    }
+
+    private XmlPage getAtomPage() throws Exception {
+        return (XmlPage) j.createWebClient().goTo("rssAll", "application/atom+xml");
+    }
+
+    private void assertAllAtomLinksContainRootUrl(NodeList allLinks) throws Exception {
+        for (int i = 0; i < allLinks.getLength(); i++) {
+            Node item = allLinks.item(i);
+            Node hrefAttr = item.getAttributes().getNamedItem("href");
+            String url = hrefAttr.getNodeValue();
+            assertThat(url, containsString(j.getURL().toString()));
+        }
+    }
+}


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4188
See [JENKINS-59167](https://issues.jenkins-ci.org/browse/JENKINS-59167).

Regression introduced in [JENKINS-58595](https://issues.jenkins-ci.org/browse/JENKINS-58595) (released as 2.190).

The variable `rootURL` is first defined in [RSS:80](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/RSS.java#L80) but then overriden in [Functions.initPageVariables](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/Functions.java#L244-L247) that's call by the new `l:view` tag introduced.

To solve the problem, I am just using the existing `app.rootUrl` which corresponds to `Jenkins.getRoolUrl()`.

For sample files, please refer to the Jira ticket.

### Proposed changelog entries

* Correction of the missing absolute URL in the RSS / Atom feeds

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<at>jvz 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

