### PR TITLE
Mirror of jenkinsci jenkins#4193

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.33</remoting.version>
+    <remoting.version>3.35</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4193
See [JENKINS-59094](https://issues.jenkins-ci.org/browse/JENKINS-59094). This corrects an issue introduced in Remoting 3.34 with some tunneling configurations. The 3.35 release retains the enhancements introduced in 3.34 and corrects the regression reported in 59094. This PR change is located at jenkinsci/remoting#345.

This Remoting release also contains a few other minor cleanup changes, which didn't need a JIRA filed.

See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.35)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Update Remoting from 3.33 to 3.35. ([issue 59094](https://issues.jenkins-ci.org/browse/JENKINS-59094), [full changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.35))

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

