### PR TITLE
Mirror of jenkinsci jenkins#4192

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ push-build.sh
 war/node_modules/
 war/yarn-error.log
 .java-version
+*.pem
+
+settings-release.xml

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,206 @@
+// -*- Groovy -*-
+/*
+  Require credentials:
+    - Microsoft Azure Service Principal
+    - Azure Storage Account
+
+  Maven docker image cannot be run with the root user
+  https://batmat.net/2017/01/30/do-not-run-your-tests-in-continuous-integration-with-the-root-user/
+  Docker container related to jenkins-jnlp require:
+  * uid 1000,
+  * gid 1000
+  * /home/jenkins/.jenkins
+
+  Jenkins Plugins:
+    * Azure-Credentials
+    * SSH-agent
+
+  docker image olblak/maven is just a customized docker image based on maven where maven is run as
+  user jenkins with uid 1000 and gid 1000, there is also a volume /home/jenkins/.jenkins defined in the image
+  otherwise the directory is created with root permission and Jenkins cannot add files there
+*/
+
+pipeline {
+    agent {
+      kubernetes {
+        label 'jenkins-release'
+        defaultContainer 'jnlp'
+        yaml '''
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: jenkins-release
+spec:
+  containers:
+  - name: maven
+    image: olblak/maven:3-jdk-8
+    imagePullPolicy: Always
+    workdir: /home/jenkins
+    env:
+      - name: HOME
+        value: "/home/jenkins"
+    command:
+    - cat
+    tty: true
+  - name: azure-cli
+    image: microsoft/azure-cli:2.0.59
+    workdir: /home/jenkins
+    command:
+    - cat
+    tty: true
+'''
+      }
+    }
+
+    options {
+      buildDiscarder logRotator(
+        artifactDaysToKeepStr: '',
+        artifactNumToKeepStr: '',
+        daysToKeepStr: '',
+        numToKeepStr: '10'
+      )
+      disableConcurrentBuilds()
+    }
+    triggers {
+      // Trigger a new release once a week on Sunday
+      cron('H H(0-7) * * 0')
+    }
+
+    environment {
+      GIT_EMAIL                     = 'jenkins-bot@example.com'
+      GIT_NAME                      = 'jenkins-bot'
+      GIT_SSH_COMMAND               = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      GPG_FILE                      = 'gpg-test-jenkins-release.gpg'
+      GPG_KEYNAME                   = 'test-jenkins-release'
+      GPG_PASSPHRASE                = credentials('release-gpg-passphrase')
+      JENKINS_WAR                   = "$WORKSPACE/war/target/jenkins.war"
+      JENKINS_ASC                   = "$WORKSPACE/war/target/jenkins.war.asc"
+      MAVEN_REPOSITORY_URL          = "http://nexus/repository"
+      MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
+      MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')
+      SIGN_ALIAS                    = 'jenkins'
+      SIGN_KEYSTORE                 = "$WORKSPACE/jenkins.pfx"
+      SIGN_STOREPASS                = credentials('signing-cert-pass')
+    }
+
+    stages {
+      stage('Clean Release') {
+        steps {
+          container('maven') {
+            checkout scm
+            sh 'scripts/buildJenkins.bash --cleanRelease'
+          }
+        }
+      }
+      stage('Retrieve Signing Certificate') {
+        environment {
+          AZURE_VAULT_NAME              = 'prodreleasecore'
+          AZURE_VAULT_CERT              = 'prodreleasecore'
+          AZURE_VAULT_FILE              = 'jenkins.pem'
+          AZURE_VAULT_CLIENT_ID         = credentials('azure-vault-client-id')
+          AZURE_VAULT_CLIENT_SECRET     = credentials('azure-vault-client-secret')
+          AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
+        }
+
+        steps {
+          container('azure-cli') {
+            // TODO move into a shell script in the repository
+            sh '''
+              az login --service-principal \
+                -u "$AZURE_VAULT_CLIENT_ID" \
+                -p "$AZURE_VAULT_CLIENT_SECRET" \
+                -t "$AZURE_VAULT_TENANT_ID"
+              # Download Certificate from Azure KeyVault
+              az keyvault secret download \
+                --vault-name "$AZURE_VAULT_NAME" \
+                --name "$AZURE_VAULT_CERT" \
+                --file "$AZURE_VAULT_FILE"
+              # Convert private/public key to a pkcs12 keystore
+              scripts/buildJenkins.bash --configureKeystore
+            '''
+          }
+        }
+      }
+      stage('Retrieve Signing GPG key') {
+        environment {
+          AZURE_STORAGE_ACCOUNT         = 'prodreleasecore'
+          AZURE_STORAGE_CONTAINER_NAME  = 'gpg'
+          AZURE_STORAGE_KEY             = credentials('gpg-storage-account-key')
+        }
+
+        steps {
+          container('azure-cli') {
+            sh '''
+              az storage blob download \
+              --account-name $AZURE_STORAGE_ACCOUNT \
+              --container-name $AZURE_STORAGE_CONTAINER_NAME \
+              --name "$GPG_FILE" \
+              --file "$GPG_FILE"
+            '''
+          }
+        }
+      }
+      stage('Prepare Release') {
+        steps {
+          container('maven') {
+            // Maven required git push permission on https://github.com/jenkinsci/jenkins
+            sshagent(['release-key']) {
+              // Maven Release requires gpg key with password password and a certificate key with password
+              sh '''
+                scripts/buildJenkins.bash --configureGPG
+                scripts/buildJenkins.bash --configureGit
+                scripts/buildJenkins.bash --prepareRelease
+              '''
+              script {
+                def properties = readProperties file: 'release.properties'
+                env.RELEASE_SCM_TAG = properties['scm.tag']
+                env.RELEASE_VERSION = properties['project.rel.org.jenkins-ci.main:jenkins-war']
+              }
+            }
+          }
+        }
+      }
+      stage('Push Commits') {
+        steps {
+          container('maven') {
+            sshagent(['release-key']) {
+              // By default git config url is set to https instead of ssh
+              // We want to only commit on the local repository used by a jenkins job
+              // and not the one defined from pom.xml
+              sh '''
+                sed -i 's#url = https://github.com/#url = git@github.com:#' .git/config
+                git push origin "HEAD:$BRANCH_NAME" "$RELEASE_SCM_TAG"
+              '''
+            }
+          }
+        }
+      }
+      stage('Perform Release') {
+        steps {
+          container('maven') {
+            // Maven required git push permission on https://github.com/jenkinsci/jenkins
+            sshagent(['release-key']) {
+              sh '''
+                scripts/buildJenkins.bash --performRelease
+                gpg --verify "$JENKINS_ASC" "$JENKINS_WAR"
+                unzip -qc "$JENKINS_WAR" META-INF/MANIFEST.MF | grep 'Jenkins-Version' | awk '{print $2}'
+                '''
+            }
+          }
+        }
+      }
+    }
+    post {
+    /*
+        always {
+            cleanWs()
+        }
+    */
+        failure {
+            input '''Pipeline failed.
+We will keep the build pod around to help you diagnose any failures.
+Select Proceed or Abort to terminate the build pod'''
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.7</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -683,6 +683,31 @@ THE SOFTWARE.
       <build>
         <plugins>
           <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+              <altDeploymentRepository>releases::${ env.MAVEN_REPOSITORY_URL}/maven-releases/</altDeploymentRepository>
+              <altSnapshotDeploymentRepository>releases-snapshot::${ env.MAVEN_REPOSITORY_URL }/maven-snapshots</altSnapshotDeploymentRepository>
+              <deployAtEnd>false</deployAtEnd>
+              <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-release-plugin</artifactId>
+            <configuration>
+              <!-- enable release profile during the release, create IPS package, and sign bits. -->
+                    <!-- Skip Test <arguments>-P release,sign -DskipTests=true</arguments>-->
+              <arguments>-P release,sign</arguments>
+              <!-- work around for a bug in javadoc plugin that causes the release to fail. see MRELEASE-271 -->
+              <preparationGoals>clean install</preparationGoals>
+                  <!-- Skipp Test <goals>-DskipTests -Danimal.sniffer.skip=false javadoc:javadoc deploy</goals>-->
+              <goals>-Danimal.sniffer.skip=false javadoc:javadoc deploy</goals>
+              <!--<goals>javadoc:javadoc deploy</goals>-->
+              <pushChanges>false</pushChanges>
+              <localCheckout>true</localCheckout>
+              <tagNameFormat>release-@{project.version}</tagNameFormat>
+            </configuration>
+          </plugin>
+          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
             <inherited>false</inherited>
             <executions>
@@ -711,6 +736,24 @@ THE SOFTWARE.
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <keyname>${env.GPG_KEYNAME}</keyname>
+              <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+              <!-- This is necessary for gpg to not try to use the pinentry programs -->
+              <gpgArguments>
+                  <arg>--pinentry-mode</arg>
+                  <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jarsigner-plugin</artifactId>
+            <configuration>
+              <keystore>${env.SIGN_KEYSTORE}</keystore>
+              <alias>${env.SIGN_ALIAS}</alias>
+              <storepass>${env.SIGN_STOREPASS}</storepass>
+              <keypass>${env.SIGN_STOREPASS}</keypass>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/scripts/buildJenkins.bash
+++ b/scripts/buildJenkins.bash
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+set -e    # Abort script at first error
+set -u    # Attempt to use undefined variable outputs error message, and forces an exit
+
+# https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
+# mvn -Prelease help:active-profiles
+
+# Temporary
+WORKSPACE="/tmp"
+
+: "${BRANCH_NAME:=experimental}"
+: "${GIT_REPOSITORY:=scm:git:git://github.com/jenkinsci/jenkins.git}"
+: "${GIT_EMAIL:=jenkins-bot@example.com}"
+: "${GIT_NAME:=jenkins-bot}"
+: "${GPG_KEYNAME:=test-jenkins-release}"
+: "${SIGN_ALIAS:=jenkins}"
+: "${SIGN_KEYSTORE:=${WORKSPACE}/jenkins.pfx}"
+: "${SIGN_CERTIFICATE:=jenkins.pem}"
+: "${MAVEN_PROFILE:=release}"
+: "${MAVEN_REPOSITORY_USERNAME:=jenkins-bot}"
+: "${MAVEN_REPOSITORY_URL:=http://nexus/repository}"
+
+export GIT_REPOSITORY
+export GIT_EMAIL
+export GIT_NAME
+export GPG_KEYNAME
+export GPG_PASSPHRASE
+export MAVEN_PROFILE
+export MAVEN_REPOSITORY_PASSWORD
+export MAVEN_REPOSITORY_URL
+export MAVEN_REPOSITORY_USERNAME
+export SIGN_ALIAS
+export SIGN_KEYSTORE
+export SIGN_STOREPASS
+export SIGN_CERTIFICATE
+
+function requireRepositoryPassword(){
+  : "${MAVEN_REPOSITORY_PASSWORD:?Repository Password Missing}"
+}
+
+function requireGPGPassphrase(){
+  : "${GPG_PASSPHRASE:?GPG Passphrase Required}" # Password must be the same for gpg agent and gpg key
+}
+
+function requireKeystorePass(){
+  : "${SIGN_STOREPASS:?pass}"
+}
+
+function clean(){
+    mvn -P"${MAVEN_PROFILE}" -s settings-release.xml -B  release:clean
+}
+
+function configureGit(){
+  git checkout "${BRANCH_NAME}"
+  git config --local user.email "${GIT_EMAIL}"
+  git config --local user.name "${GIT_NAME}"
+}
+
+function configureGPG(){ 
+  requireGPGPassphrase
+  if ! gpg --fingerprint "${GPG_KEYNAME}"; then
+    if [ ! -f "${GPG_FILE}" ]; then
+      exit "${GPG_KEYNAME} or ${GPG_FILE} cannot be found"
+    else
+      ## --pinenty-mode is needed to avoid gpg prompt during maven release
+      gpg --import --batch "${GPG_FILE}"
+    fi
+  fi
+}
+
+
+function configureKeystore(){
+  requireKeystorePass
+  if [ ! -f ${SIGN_CERTIFICATE} ]; then
+      exit "${SIGN_CERTIFICATE} not found"
+  else
+    openssl pkcs12 -export \
+      -out $SIGN_KEYSTORE \
+      -in ${SIGN_CERTIFICATE} \
+      -password pass:$SIGN_STOREPASS \
+      -name $SIGN_ALIAS
+  fi
+}
+
+function generateSettingsXml(){
+requireRepositoryPassword
+cat <<EOT> settings-release.xml
+<settings>
+  <mirrors>
+    <mirror>
+      <id>mirror-jenkins-public</id>
+      <url>http://nexus/repository/jenkins-public/</url>
+      <mirrorOf>repo.jenkins-ci.org</mirrorOf>
+    </mirror>
+  </mirrors>
+  <servers>
+    <server>
+      <id>releases-snapshots</id>
+      <username>$MAVEN_REPOSITORY_USERNAME</username>
+      <password>$MAVEN_REPOSITORY_PASSWORD</password>
+    </server>
+    <server>
+      <id>releases</id>
+      <username>$MAVEN_REPOSITORY_USERNAME</username>
+      <password>$MAVEN_REPOSITORY_PASSWORD</password>
+    </server>
+    <server>
+      <id>mirror-jenkins-public</id>
+      <username>$MAVEN_REPOSITORY_USERNAME</username>
+      <password>$MAVEN_REPOSITORY_PASSWORD</password>
+    </server>
+  </servers>
+
+</settings>
+EOT
+}
+
+
+function prepareRelease(){
+  requireGPGPassphrase
+  requireKeystorePass
+  printf "\\n Prepare Jenkins Release\\n\\n"
+  mvn -P"${MAVEN_PROFILE}" -s settings-release.xml -B release:prepare
+}
+
+function performRelease(){
+  requireGPGPassphrase
+  requireKeystorePass
+  printf "\\n Perform Jenkins Release\\n\\n"
+  mvn -P"${MAVEN_PROFILE}" -s settings-release.xml -B release:perform
+}
+
+function validateKeystore(){
+  requireKeystorePass
+  keytool -keystore "${SIGN_KEYSTORE}" -storepass "${SIGN_STOREPASS}" -list -alias "${SIGN_ALIAS}"
+}
+function validateGPG(){
+  true
+}
+
+function main(){
+  if [ $# -eq 0 ] ;then
+    configureGPG
+    configureKeystore
+    configureGit
+    validateKeystore
+    validateGPG
+    generateSettingsXml
+    prepareRelease
+    performRelease
+  else
+    while [ $# -gt 0 ];
+    do
+      case "$1" in
+            --cleanRelease) echo "Clean Release" && generateSettingsXml && clean;;
+            --configureGPG) echo "ConfigureGPG" && configureGPG ;;
+            --configureKeystore) echo "Configure Keystore" && configureKeystore ;;
+            --configureGit) echo "Configure Git" && configureGit ;;
+            --validateKeystore) echo "Validate Keystore"  && validateKeystore ;;
+            --validateGPG) echo "Validate GPG" && validateGPG ;;
+            --prepareRelease) echo "Prepare Release" && generateSettingsXml && prepareRelease ;;
+            --performRelease) echo "Perform Release" && performRelease ;;
+            -h) echo "help" ;;
+            -*) echo "help" ;;
+        esac
+        shift
+    done
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4192
See [INFRA-2252](https://issues.jenkins-ci.org/browse/INFRA-2252).

This PR is currently being tested on [release.ci.jenkins.io](https://release.ci.jenkins.io) which required [vpn](https://github.com/jenkins-infra/openvpn#howto-get-client-access) access
That jenkins configuration instance is located on [jenkins-infra/charts](https://github.com/jenkins-infra/charts/blob/master/helmfile.d/release.yaml) repository 

ToDo:
[ ] Move kubernetes agent configuration to the Jenkins configuration located [here](https://github.com/jenkins-infra/charts/blob/26e843566331785586b02aed87e26ba28ff51dce/config/release/jenkins/values.yaml#L5)
[ ] Retrieve the GPG key from Azure Key Vault instead of an Azure blob storage

### Proposed changelog entries

* Internal: Add a bash script and a Jenkinsfile to build Jenkins core releases
* Internal: Update maven-deploy-plugin

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<at>mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

