### PR TITLE
Mirror of jenkinsci jenkins#4202

### DIFF
--- a/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
@@ -23,6 +23,7 @@
  */
 package hudson.lifecycle;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 
 import org.kohsuke.accmod.Restricted;
@@ -59,6 +60,7 @@ public class ExitLifecycle extends Lifecycle {
     }
 
     @Override
+    @SuppressFBWarnings(value = "DM_EXIT", justification = "Exit is really intended.")
     public void restart() {
         Jenkins jenkins = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
 

--- a/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
@@ -23,6 +23,7 @@
  */
 package hudson.lifecycle;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
@@ -39,6 +40,7 @@ public class SolarisSMFLifecycle extends Lifecycle {
      * In SMF managed environment, just commit a suicide and the service will be restarted by SMF.
      */
     @Override
+    @SuppressFBWarnings(value = "DM_EXIT", justification = "Exit is really intended.")
     public void restart() throws IOException, InterruptedException {
         Jenkins jenkins = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
         try {

--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -24,6 +24,7 @@
 package hudson.lifecycle;
 
 import com.sun.jna.Native;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Functions;
 import hudson.Launcher.LocalLauncher;
 import hudson.model.ManagementLink;
@@ -188,6 +189,7 @@ public class WindowsInstallerLink extends ManagementLink {
 
         // initiate an orderly shutdown after we finished serving this request
         new Thread("terminator") {
+            @SuppressFBWarnings(value = "DM_EXIT", justification = "Exit is really intended.")
             public void run() {
                 try {
                     Thread.sleep(1000);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.thoughtworks.xstream.XStream;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.*;
 import hudson.Launcher.LocalLauncher;
 import jenkins.AgentProtocol;
@@ -848,9 +849,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @param pluginManager
      *      If non-null, use existing plugin manager.  create a new one.
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({
+    @SuppressFBWarnings({
         "SC_START_IN_CTOR", // bug in FindBugs. It flags UDPBroadcastThread.start() call but that's for another class
-        "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" // Trigger.timer
+        "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", // Trigger.timer
+        "DM_EXIT" // Exit is wanted here
     })
     protected Jenkins(File root, ServletContext context, PluginManager pluginManager) throws IOException, InterruptedException, ReactorException {
         oldJenkinsJVM = JenkinsJVM.isJenkinsJVM(); // capture to restore in cleanUp()
@@ -4373,6 +4375,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         new Thread("exit thread") {
             @Override
+            @SuppressFBWarnings(value = "DM_EXIT", justification = "Exit is really intended.")
             public void run() {
                 try {
                     ACL.impersonate(ACL.SYSTEM);
@@ -4401,6 +4404,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         final String exitAddr = req!=null ? req.getRemoteAddr() : "unknown";
         new Thread("safe-exit thread") {
             @Override
+            @SuppressFBWarnings(value = "DM_EXIT", justification = "Exit is really intended.")
             public void run() {
                 try {
                     ACL.impersonate(ACL.SYSTEM);


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4202
See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

All calls for System.exit are reasonable, so I suppressed the Warning on the methods.
This removes 6 Spotbugs warnings, so that we have 421 open issues (without the other PRs)

### Proposed changelog entries

* Internal: Spotbugs supressions

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


