### PR TITLE
Mirror of jenkinsci jenkins#4200

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1429,7 +1429,6 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      */
     private boolean isAllSuitableNodesOffline(R build) {
         Label label = getAssignedLabel();
-        List<Node> allNodes = Jenkins.get().getNodes();
 
         if (label != null) {
             //Invalid label. Put in queue to make administrator fix

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -663,7 +663,6 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     @Override
     public void movedTo(DirectlyModifiableTopLevelItemGroup destination, AbstractItem newItem, File destDir) throws IOException {
-        Job newJob = (Job) newItem; // Missing covariant parameters type here.
         File oldBuildDir = getBuildDir();
         super.movedTo(destination, newItem, destDir);
         File newBuildDir = getBuildDir();

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -1355,7 +1355,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     private static View copy(StaplerRequest req, ViewGroup owner, String name) throws IOException {
         View v;
         String from = req.getParameter("from");
-        View src = src = owner.getView(from);
+        View src = owner.getView(from);
 
         if(src==null) {
             if(Util.fixEmpty(from)==null)

--- a/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
+++ b/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
@@ -121,7 +121,7 @@ public abstract class BuildStepCompatibilityLayer implements BuildStep {
     @Deprecated
     public boolean perform(Build<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {       
-        if (build instanceof AbstractBuild && Util.isOverridden(BuildStepCompatibilityLayer.class, this.getClass(),
+        if (build != null && Util.isOverridden(BuildStepCompatibilityLayer.class, this.getClass(),
                 "perform", AbstractBuild.class, Launcher.class, BuildListener.class)) {
             return perform((AbstractBuild<?, ?>) build, launcher, listener);
         }

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -133,20 +133,17 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
          * @return a downloadable object
          */
         public Downloadable createDownloadable() {
-            if (this instanceof DownloadFromUrlInstaller.DescriptorImpl) {
-                final DownloadFromUrlInstaller.DescriptorImpl delegate = this;
-                return new Downloadable(getId()) {
-                    public JSONObject reduce(List<JSONObject> jsonList) {
-                        if (isDefaultSchema(jsonList)) {
-                            return delegate.reduce(jsonList);
-                        } else {
-                            //if it's not default schema fall back to the super class implementation
-                            return super.reduce(jsonList);
-                        }
+            final DescriptorImpl delegate = this;
+            return new Downloadable(getId()) {
+                public JSONObject reduce(List<JSONObject> jsonList) {
+                    if (isDefaultSchema(jsonList)) {
+                        return delegate.reduce(jsonList);
+                    } else {
+                        //if it's not default schema fall back to the super class implementation
+                        return super.reduce(jsonList);
                     }
-                };
-            }
-            return new Downloadable(getId());
+                }
+            };
         }
 
         /**


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4200
See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

Fixed 5 spotbugs issues.
* [SA_LOCAL_DOUBLE_ASSIGNMENT](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#sa-double-assignment-of-local-variable-sa-local-double-assignment)
* [BC_VACUOUS_INSTANCEOF](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#bc-instanceof-will-always-return-true-bc-vacuous-instanceof)
* [DLS_DEAD_LOCAL_STORE](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#dls-useless-assignment-in-return-statement-dls-dead-local-store-in-return)

### Proposed changelog entries

* Internal: Minor internal improvements

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers



