### PR TITLE
Mirror of jenkinsci jenkins#4204

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -875,9 +875,11 @@ public class Util {
                     if (!escaped) {
                         out = new StringBuilder(i + (m - i) * 3);
                         out.append(s, 0, i);
+                        escaped = true;
+                    }
+                    if (enc == null || buf == null) {
                         enc = StandardCharsets.UTF_8.newEncoder();
                         buf = CharBuffer.allocate(1);
-                        escaped = true;
                     }
                     // 1 char -> UTF8
                     buf.put(0, c);

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -158,7 +158,8 @@ public class UtilTest {
             " \"#%/:;<>?", "%20%22%23%25%2F%3A%3B%3C%3E%3F",
             "[\\]^`{|}~", "%5B%5C%5D%5E%60%7B%7C%7D%7E",
             "d\u00E9velopp\u00E9s", "d%C3%A9velopp%C3%A9s",
-            "Foo \uD800\uDF98 Foo", "Foo%20%F0%90%8E%98%20Foo"
+            "Foo \uD800\uDF98 Foo", "Foo%20%F0%90%8E%98%20Foo",
+            "\u00E9 ", "%C3%A9%20"
         };
         for (int i = 0; i < data.length; i += 2) {
             assertEquals("test " + i, data[i + 1], Util.rawEncode(data[i]));


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4204
See [JENKINS-59406](https://issues.jenkins-ci.org/browse/JENKINS-59406) This fixes an issue introduced in [JENKINS-23349](https://issues.jenkins-ci.org/browse/JENKINS-23349).

The above JIRA introduced an error where UTF-8 characters that were followed by a space caused the rawEncode function to throw a nullpointer exception. 

### Proposed changelog entries

* Entry 1: Internal: Ensure objects are initialized before they are used

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<at>mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

