### PR TITLE
Mirror of jenkinsci jenkins#4462

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -271,15 +271,17 @@ public class ListView extends View implements DirectlyModifiableView {
     }
     
     private void includeItems(ItemGroup<? extends TopLevelItem> root, Collection<? extends Item> parentItems, SortedSet<String> names) {
-        for (Item item : parentItems) {
-            if (recurse && item instanceof ItemGroup) {
-                ItemGroup<?> ig = (ItemGroup<?>) item;
-                includeItems(root, ig.getItems(), names);
-            }
-            if (item instanceof TopLevelItem) {
-                String itemName = item.getRelativeNameFrom(root);
-                if (includePattern.matcher(itemName).matches()) {
-                    names.add(itemName);
+        if (includePattern != null) {
+            for (Item item : parentItems) {
+                if (recurse && item instanceof ItemGroup) {
+                    ItemGroup<?> ig = (ItemGroup<?>) item;
+                    includeItems(root, ig.getItems(), names);
+                }
+                if (item instanceof TopLevelItem) {
+                    String itemName = item.getRelativeNameFrom(root);
+                    if (includePattern.matcher(itemName).matches()) {
+                        names.add(itemName);
+                    }
                 }
             }
         }

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -211,18 +211,15 @@ public class ListView extends View implements DirectlyModifiableView {
         }
 
         ItemGroup<? extends TopLevelItem> parent = getOwner().getItemGroup();
-        List<TopLevelItem> parentItems = null;
-        if (includePattern != null) {
-            parentItems = new ArrayList<>(parent.getItems());
-            includeItems(parent, parentItems, names);
-        }
+        List<TopLevelItem> parentItems = new ArrayList<>(parent.getItems());
+        includeItems(parent, parentItems, names);
 
         Boolean statusFilter = this.statusFilter; // capture the value to isolate us from concurrent update
         Iterable<? extends TopLevelItem> candidates;
         if (recurse) {
             candidates = parent.getAllItems(TopLevelItem.class);
         } else {
-            candidates = parentItems != null ? parentItems : parent.getItems();
+            candidates = parentItems;
         }
         for (TopLevelItem item : candidates) {
             if (!names.contains(item.getRelativeNameFrom(getOwner().getItemGroup()))) continue;


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4462
While investigating an issue stumbled upon this double call of `parent.getItems` use the cached value of the first instead of calling it twice to prevent double checks of ACLs

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Improve performance of ListViews
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<at>mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention <at>jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`


