### PR TITLE
Mirror of jenkinsci jenkins#4461

### DIFF
--- a/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
@@ -124,6 +124,11 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
     }
 
     private void error(Computer c, Throwable x) {
+        // JENKINS-54496: don't log if c was removed from Jenkins after we'd started monitoring
+        final boolean cIsStillCurrent = Jenkins.get().getComputer(c.getName()) == c;
+        if (!cIsStillCurrent) {
+            return;
+        }
         if (c instanceof SlaveComputer) {
             Functions.printStackTrace(x, ((SlaveComputer) c).getListener().error("Failed to monitor for " + getDisplayName()));
         } else {


### PR DESCRIPTION
Mirror of jenkinsci jenkins#4461
See [JENKINS-54496](https://issues.jenkins-ci.org/browse/JENKINS-54496).

### Description

Logging enhancement:
We now ignore slave-node-monitoring exceptions regarding nodes that were deleted (e.g. by cloud-provisioning processes) while the monitoring was still in progress.
i.e. this (harmless) race condition no longer causes messy exceptions in the log.

No unit-tests added: `hudson.node_monitors.AbstractAsyncNodeMonitorDescriptor` doesn't appear to have any unit tests, and this change didn't justify adding any.

### Proposed changelog entries

N/A... or
```
type: rfe
message: Avoid logging node-monitoring exceptions caused by node deletion.
issue: 54496
```

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] ~Appropriate autotests or~ explanation to why this change has no tests
- [x] ~For dependency updates: links to external changelogs and, if possible, full diffs~

### Desired reviewers

<at>jeffret-b

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [x] ~If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))~
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`
